### PR TITLE
[Feat]: 퀴즈 컴포넌트 구조 임시 구현

### DIFF
--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -7,16 +7,25 @@ import {
 } from '../../shared/drawer';
 import TextField from '@eolluga/eolluga-ui/Input/TextField';
 import Icon from '@eolluga/eolluga-ui/icon/Icon';
+import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useState } from 'react';
 import FlexBox from '../../shared/FlexBox';
+import { Comment } from '@/types';
+import { Dropdown } from './common';
 
 type BottomSheetProps = {
   isOpen: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  comments: Comment[];
 };
 
-export default function BottomSheet({ isOpen, setOpen }: BottomSheetProps) {
+export default function BottomSheet({ isOpen, setOpen, comments }: BottomSheetProps) {
   const [inputValue, setInputValue] = useState<string>('');
+  const [sortOption, setSortOption] = useState<string>('최신 순'); // 정렬 옵션 상태
+
+  const handleSortOptionChange = (option: string) => {
+    setSortOption(option);
+  };
 
   return (
     <Drawer open={isOpen} onOpenChange={setOpen}>
@@ -24,12 +33,41 @@ export default function BottomSheet({ isOpen, setOpen }: BottomSheetProps) {
         <DrawerHeader className="relative">
           <DrawerTitle>댓글</DrawerTitle>
           <DrawerDescription />
-          <button type="button" className="absolute top-5 right-7" onClick={() => setOpen(!isOpen)}>
-            <Icon icon="close" />
-          </button>
+          <div className="flex items-center gap-2">
+            <Dropdown
+              options={['최신 순', '좋아요 순']}
+              selectedOption={sortOption}
+              onOptionSelect={handleSortOptionChange}
+            />
+            <button
+              type="button"
+              className="absolute top-5 right-7"
+              onClick={() => setOpen(!isOpen)}
+            >
+              <Icon icon="close" />
+            </button>
+          </div>
         </DrawerHeader>
-        <div className="flex flex-col space-y-4 justify-between h-full"></div>
 
+        <div className="flex flex-col space-y-4 justify-between h-full">
+          <div className="overflow-y-auto p-4">
+            {comments.length > 0 ? (
+              comments.map((comment) => (
+                <div key={comment.id} className="mb-4 flex items-start gap-3 border-b pb-2">
+                  <Avatar size="S" />
+                  <div>
+                    <div className="text-sm font-bold">{comment.author}</div>
+                    <p className="text-sm text-gray-600">{comment.content}</p>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-gray-500">
+                아직 댓글이 없습니다. 첫 번째로 댓글을 남겨보세요!
+              </p>
+            )}
+          </div>
+        </div>
         <div className="w-full border-t-2 fixed bottom-4 pt-3 bg-white">
           <FlexBox className="px-4 gap-4">
             <TextField

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -11,7 +11,6 @@ import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useState } from 'react';
 import FlexBox from '../../shared/FlexBox';
 import { Comment } from '@/types';
-import { Dropdown } from './common';
 
 type BottomSheetProps = {
   isOpen: boolean;
@@ -34,11 +33,11 @@ export default function BottomSheet({ isOpen, setOpen, comments }: BottomSheetPr
           <DrawerTitle>댓글</DrawerTitle>
           <DrawerDescription />
           <div className="flex items-center gap-2">
-            <Dropdown
+            {/* <Dropdown
               options={['최신 순', '좋아요 순']}
               selectedOption={sortOption}
               onOptionSelect={handleSortOptionChange}
-            />
+            /> */}
             <button
               type="button"
               className="absolute top-5 right-7"

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+
+type DropDownProps = {
+  items: string[];
+  selectedItem: string;
+  setItem: (item: string) => void;
+  placeholder?: string;
+};
+
+const DropDown = ({ items, selectedItem, setItem, placeholder = '' }: DropDownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<string>(selectedItem);
+
+  const handleSelect = (value: string) => {
+    setSelected(value);
+    setItem(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        className="w-full flex justify-between items-center bg-white border border-gray-300 rounded-md px-4 py-2 text-left shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <span>{selected ? items.find((item) => item === selected) : placeholder}</span>
+        <Icon
+          className="ml-2 h-5 w-5 text-gray-500"
+          icon={isOpen ? 'chevron_up_outlined' : 'chevron_down_outlined'}
+        />
+      </button>
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg">
+          <ul className="max-h-60 overflow-auto">
+            {items.map((item) => (
+              <li
+                key={item}
+                className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+                onClick={() => handleSelect(item)}
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DropDown;

--- a/src/components/common/Quiz/QuizAB.tsx
+++ b/src/components/common/Quiz/QuizAB.tsx
@@ -1,0 +1,24 @@
+import type { QuizAB as QuizABType } from '@/types';
+
+function QuizAB({ quiz, onAnswer }: { quiz: QuizABType; onAnswer?: (answer: string) => void }) {
+  const handleOptionClick = (option: string) => {
+    if (onAnswer) {
+      onAnswer(option);
+    }
+  };
+
+  return (
+    <div>
+      <h3>{quiz.question}</h3>
+      <div style={{ display: 'flex', justifyContent: 'space-around', marginTop: '16px' }}>
+        {quiz.options.map((option, index) => (
+          <button key={index} onClick={() => handleOptionClick(option)}>
+            {option}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default QuizAB;

--- a/src/components/common/Quiz/QuizAns.tsx
+++ b/src/components/common/Quiz/QuizAns.tsx
@@ -1,0 +1,17 @@
+interface QuizAnsProps {
+  isCorrect: boolean;
+  explanation: string;
+}
+
+function QuizAns({ isCorrect, explanation }: QuizAnsProps) {
+  return (
+    <div className={`mt-4 p-4 rounded-lg ${isCorrect ? 'bg-green-100' : 'bg-red-100'}`}>
+      <h4 className={`font-bold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
+        {isCorrect ? '정답입니다!' : '틀렸습니다 ㅠㅠ'}
+      </h4>
+      <p className={`mt-2 ${isCorrect ? 'text-green-500' : 'text-red-500'}`}>{explanation}</p>
+    </div>
+  );
+}
+
+export default QuizAns;

--- a/src/components/common/Quiz/QuizFooter.tsx
+++ b/src/components/common/Quiz/QuizFooter.tsx
@@ -1,0 +1,28 @@
+import type { Comment } from '@/types';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+
+interface QuizFooterProps {
+  likes: number;
+  comments: Comment[];
+  isLiked: boolean;
+  onToggleLike: () => void;
+  onCommentsClick: () => void;
+}
+
+function QuizFooter({ likes, comments, isLiked, onToggleLike, onCommentsClick }: QuizFooterProps) {
+  return (
+    <div className="flex items-center mt-4 text-gray-600">
+      <button className="flex items-center mr-6" onClick={onToggleLike} aria-label="좋아요">
+        <Icon icon={isLiked ? 'heart_filled' : 'heart_outlined'} />
+        <span className="ml-1">{likes}</span>
+      </button>
+
+      <button className="flex items-center" onClick={onCommentsClick} aria-label="댓글">
+        <Icon icon="chat" />
+        <span className="ml-1">{comments.length}</span>
+      </button>
+    </div>
+  );
+}
+
+export default QuizFooter;

--- a/src/components/common/Quiz/QuizMul.tsx
+++ b/src/components/common/Quiz/QuizMul.tsx
@@ -1,0 +1,28 @@
+import type { QuizMul as QuizMulType } from '@/types';
+
+interface QuizMulProps {
+  quiz: QuizMulType;
+  onAnswerSelect: (answer: string) => void;
+}
+
+function QuizMul({ quiz, onAnswerSelect }: QuizMulProps) {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold">{quiz.question}</h3>
+      <ul className="space-y-2 mt-4">
+        {quiz.options.map((option, index) => (
+          <li key={index}>
+            <button
+              className="w-full px-4 py-2 bg-gray-200 rounded"
+              onClick={() => onAnswerSelect(option)}
+            >
+              {option}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default QuizMul;

--- a/src/components/common/Quiz/QuizOX.tsx
+++ b/src/components/common/Quiz/QuizOX.tsx
@@ -1,0 +1,31 @@
+import type { QuizOX as QuizOXType } from '@/types';
+
+interface QuizOXProps {
+  quiz: QuizOXType;
+  onAnswerSelect: (answer: string) => void;
+}
+
+function QuizOX({ quiz, onAnswerSelect }: QuizOXProps) {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-4">{quiz.question}</h3>
+
+      <div className="flex justify-between">
+        <button
+          className="flex-1 text-center py-3 border border-gray-300 rounded-l-lg bg-white hover:bg-blue-100"
+          onClick={() => onAnswerSelect('O')}
+        >
+          O
+        </button>
+        <button
+          className="flex-1 text-center py-3 border border-gray-300 rounded-r-lg bg-white hover:bg-blue-100"
+          onClick={() => onAnswerSelect('X')}
+        >
+          X
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default QuizOX;

--- a/src/components/common/Quiz/QuizWrapper.tsx
+++ b/src/components/common/Quiz/QuizWrapper.tsx
@@ -2,7 +2,7 @@ import { Quiz } from '@/types';
 import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useState } from 'react';
 import { QuizAB, QuizAns, QuizFooter, QuizMul, QuizOX } from '.';
-import BottomSheet from '@/components/BottomSheet';
+import BottomSheet from '../BottomSheet';
 
 interface QuizWrapperProps {
   quiz: Quiz;
@@ -36,33 +36,34 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
     return null;
   };
 
-  return (<>
-    <div
-      className="border rounded-lg shadow-sm p-4 mb-4 bg-white"
-      style={{ maxWidth: '600px', margin: '0 auto' }}
-    >
-      <div className="flex items-center mb-4">
-        <Avatar size="S" />
-        <div className="ml-4">
-          <h4 className="text-md font-bold">{quiz.author}</h4>
-          <p className="text-sm text-gray-500">
-            {quiz.type === 'OX' ? 'OX 퀴즈' : quiz.type === 'ABTest' ? 'A/B 테스트' : '객관식'}
-          </p>
+  return (
+    <>
+      <div
+        className="border rounded-lg shadow-sm p-4 mb-4 bg-white"
+        style={{ maxWidth: '600px', margin: '0 auto' }}
+      >
+        <div className="flex items-center mb-4">
+          <Avatar size="S" />
+          <div className="ml-4">
+            <h4 className="text-md font-bold">{quiz.author}</h4>
+            <p className="text-sm text-gray-500">
+              {quiz.type === 'OX' ? 'OX 퀴즈' : quiz.type === 'ABTest' ? 'A/B 테스트' : '객관식'}
+            </p>
+          </div>
         </div>
+        {renderQuizContent()}
+        {selectedAnswer !== null && isCorrect !== null && (
+          <QuizAns isCorrect={isCorrect} explanation={quiz.explanation} />
+        )}
+        <QuizFooter
+          likes={likes}
+          comments={quiz.comments}
+          isLiked={isLiked}
+          onToggleLike={handleToggleLike}
+          onCommentsClick={() => setBottomSheetOpen(true)}
+        />
       </div>
-      {renderQuizContent()}
-      {selectedAnswer !== null && isCorrect !== null && (
-        <QuizAns isCorrect={isCorrect} explanation={quiz.explanation} />
-      )}
-      <QuizFooter
-        likes={likes}
-        comments={quiz.comments}
-        isLiked={isLiked}
-        onToggleLike={handleToggleLike}
-        onCommentsClick={() => setBottomSheetOpen(true)}
-      />
-    </div>
-    <BottomSheet
+      <BottomSheet
         isOpen={isBottomSheetOpen}
         setOpen={setBottomSheetOpen}
         comments={quiz.comments}

--- a/src/components/common/Quiz/QuizWrapper.tsx
+++ b/src/components/common/Quiz/QuizWrapper.tsx
@@ -1,0 +1,74 @@
+import { Quiz } from '@/types';
+import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
+import { useState } from 'react';
+import { QuizAB, QuizAns, QuizFooter, QuizMul, QuizOX } from '.';
+import BottomSheet from '@/components/BottomSheet';
+
+interface QuizWrapperProps {
+  quiz: Quiz;
+}
+
+function QuizWrapper({ quiz }: QuizWrapperProps) {
+  const [isLiked, setIsLiked] = useState(false);
+  const [likes, setLikes] = useState(quiz.likes);
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
+
+  const handleToggleLike = () => {
+    setIsLiked(!isLiked);
+    setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
+  };
+
+  const handleAnswerSelect = (answer: string) => {
+    setSelectedAnswer(answer);
+    setIsCorrect(answer === quiz.correctAnswer);
+  };
+
+  const renderQuizContent = () => {
+    if (quiz.type === 'OX') {
+      return <QuizOX quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
+    } else if (quiz.type === 'ABTest') {
+      return <QuizAB quiz={quiz} />;
+    } else if (quiz.type === 'MultipleChoice') {
+      return <QuizMul quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
+    }
+    return null;
+  };
+
+  return (<>
+    <div
+      className="border rounded-lg shadow-sm p-4 mb-4 bg-white"
+      style={{ maxWidth: '600px', margin: '0 auto' }}
+    >
+      <div className="flex items-center mb-4">
+        <Avatar size="S" />
+        <div className="ml-4">
+          <h4 className="text-md font-bold">{quiz.author}</h4>
+          <p className="text-sm text-gray-500">
+            {quiz.type === 'OX' ? 'OX 퀴즈' : quiz.type === 'ABTest' ? 'A/B 테스트' : '객관식'}
+          </p>
+        </div>
+      </div>
+      {renderQuizContent()}
+      {selectedAnswer !== null && isCorrect !== null && (
+        <QuizAns isCorrect={isCorrect} explanation={quiz.explanation} />
+      )}
+      <QuizFooter
+        likes={likes}
+        comments={quiz.comments}
+        isLiked={isLiked}
+        onToggleLike={handleToggleLike}
+        onCommentsClick={() => setBottomSheetOpen(true)}
+      />
+    </div>
+    <BottomSheet
+        isOpen={isBottomSheetOpen}
+        setOpen={setBottomSheetOpen}
+        comments={quiz.comments}
+      />
+    </>
+  );
+}
+
+export default QuizWrapper;

--- a/src/components/common/Quiz/index.ts
+++ b/src/components/common/Quiz/index.ts
@@ -1,0 +1,6 @@
+export { default as QuizAB } from './QuizAB';
+export { default as QuizAns } from './QuizAns';
+export { default as QuizFooter } from './QuizFooter';
+export { default as QuizMul } from './QuizMul';
+export { default as QuizOX } from './QuizOX';
+export { default as QuizWrapper } from './QuizWrapper';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,3 @@
 export { default as BottomNavBar } from './BottomNavBar';
-export { default as Dropdown } from './Dropdown';
 
 export * from './Quiz';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,4 @@
 export { default as BottomNavBar } from './BottomNavBar';
+export { default as Dropdown } from './Dropdown';
+
+export * from './Quiz';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,2 @@
 export { default as BottomNavBar } from './BottomNavBar';
-
 export * from './Quiz';

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,99 @@
+import { QuizWrapper } from '@/components';
+
+const dummyQuizzes = [
+  {
+    id: 1,
+    type: 'OX',
+    author: 'React Expert',
+    authorAvatar: 'avatarUrl',
+    question: 'React의 Virtual DOM은 실제 DOM보다 항상 빠릅니까?',
+    correctAnswer: 'X',
+    explanation: 'Virtual DOM이 항상 빠른 것은 아닙니다.',
+    likes: 120,
+    comments: [
+      { id: 1, author: 'User1', authorAvatar: 'commentAvatarUrl1', content: '쉬워요' },
+      { id: 2, author: 'User2', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
+    ],
+  },
+  {
+    id: 2,
+    type: 'ABTest',
+    author: 'UI Designer',
+    authorAvatar: 'avatarUrl2',
+    question: '어떤 버튼 디자인이 더 좋으신가요?',
+    options: ['Flat Design', 'Material Design'],
+    correctAnswer: null,
+    explanation: '',
+    likes: 80,
+    comments: [],
+  },
+  {
+    id: 3,
+    type: 'MultipleChoice',
+    author: 'Quiz Master',
+    authorAvatar: 'avatarUrl3',
+    question: 'JavaScript에서 가장 널리 사용되는 ES6 기능은 무엇입니까?',
+    options: ['Arrow Functions', 'Classes', 'Modules', 'Template Literals'],
+    correctAnswer: 'Arrow Functions',
+    explanation: 'Arrow Functions는 간결하고 강력합니다.',
+    likes: 95,
+    comments: [
+      {
+        id: 1,
+        author: 'User1',
+        authorAvatar: 'commentAvatarUrl3',
+        content: '어려워요.',
+      },
+    ],
+  },
+  {
+    id: 4,
+    type: 'MultipleChoice',
+    author: 'Quiz Master',
+    authorAvatar: 'avatarUrl3',
+    question: 'JavaScript에서 가장 널리 사용되는 ES6 기능은 무엇입니까?',
+    options: ['Arrow Functions', 'Classes', 'Modules', 'Template Literals'],
+    correctAnswer: 'Arrow Functions',
+    explanation: 'Arrow Functions는 간결하고 강력합니다.',
+    likes: 95,
+    comments: [
+      {
+        id: 1,
+        author: 'User3',
+        authorAvatar: 'commentAvatarUrl3',
+        content: '정답을 보고 놀랐어요.',
+      },
+    ],
+  },
+  {
+    id: 5,
+    type: 'MultipleChoice',
+    author: 'Quiz Master',
+    authorAvatar: 'avatarUrl3',
+    question: 'JavaScript에서 가장 널리 사용되는 ES6 기능은 무엇입니까?',
+    options: ['Arrow Functions', 'Classes', 'Modules', 'Template Literals'],
+    correctAnswer: 'Arrow Functions',
+    explanation: 'Arrow Functions는 간결하고 강력합니다.',
+    likes: 95,
+    comments: [
+      {
+        id: 1,
+        author: 'User3',
+        authorAvatar: 'commentAvatarUrl3',
+        content: '정답을 보고 놀랐어요.',
+      },
+    ],
+  },
+];
+
 const MainPage = () => {
-  return <h1>메인페이지입니다.</h1>;
+  return (
+    <div style={{ marginTop: '64px', padding: '16px' }}>
+      {dummyQuizzes.map((quiz) => (
+        <QuizWrapper key={quiz.id} quiz={quiz} />
+      ))}
+    </div>
+  );
 };
 
 export default MainPage;

--- a/src/types/QuizTypes.ts
+++ b/src/types/QuizTypes.ts
@@ -1,0 +1,35 @@
+export interface Comment {
+  id: number;
+  author: string;
+  authorAvatar: string;
+  content: string;
+}
+
+export interface BaseQuiz {
+  id: number;
+  author: string;
+  authorAvatar: string;
+  question: string;
+  correctAnswer: string | null;
+  explanation: string;
+  likes: number;
+  comments: Comment[];
+  options?: string[];
+}
+
+export interface QuizOX extends BaseQuiz {
+  type: 'OX';
+  options?: undefined;
+}
+
+export interface QuizAB extends BaseQuiz {
+  type: 'ABTest';
+  options: [string, string];
+}
+
+export interface QuizMul extends BaseQuiz {
+  type: 'MultipleChoice';
+  options: string[];
+}
+
+export type Quiz = QuizOX | QuizAB | QuizMul;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './NavBarType';
+export * from './QuizTypes';


### PR DESCRIPTION
## 작업 내용

- QuizWrapper 컴포넌트 구현 및 공통 레이아웃 추가
- QuizOX, QuizAB, QuizMul 유형별 퀴즈 컴포넌트 추가
- QuizFooter에서 좋아요 및 댓글 바텀시트 연결
- QuizAns 컴포넌트로 정답/오답 해설 표시

---

git pull 과정에서 실수를 해서 한참 삽질했습니다,, 일단 PR 후 레포 새로 파서 작업이어서 하겠습니다.