### PR TITLE
[FEAT]: 퀴즈 생성 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
 import AuthLayout from './layouts/AuthLayout';
-import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
+import { LoginPage, InterestPage, CallbackPage } from './pages/login';
 import { GamePage, MainPage, MyPage, SearchPage } from './pages';
+import { AbPage, OxPage, MultipleChoicePage } from './pages/quiz';
 import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play } from './pages/game';
 import { useState } from 'react';
 import ReviewNote from './pages/profile/ReviewNote';
@@ -34,6 +35,9 @@ function App() {
           <Route path="/game/waiting" element={<WaitingRoom />} />
           <Route path="/game/random" element={<RandomMatch />} />
           <Route path="/game/entry" element={<CodeEntry />} />
+          <Route path="/quiz/ab" element={<AbPage />} />
+          <Route path="/quiz/ox" element={<OxPage />} />
+          <Route path="/quiz/multiple" element={<MultipleChoicePage />} />
           {/* 추가적인 페이지 라우팅을 등록 */}
         </Route>
         <Route path="/game/play" element={<Play />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout';
 import AuthLayout from './layouts/AuthLayout';
-import { LoginPage, InterestPage, CallbackPage } from './pages/login';
+import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
 import { GamePage, MainPage, MyPage, SearchPage } from './pages';
 import { AbPage, OxPage, MultipleChoicePage } from './pages/quiz';
 import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play } from './pages/game';

--- a/src/pages/quiz/AbPage.tsx
+++ b/src/pages/quiz/AbPage.tsx
@@ -1,0 +1,225 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import TextField from '@eolluga/eolluga-ui/Input/TextField';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+export default function ABTestPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [selectedQuizType, setSelectedQuizType] = useState('');
+  const [question, setQuestion] = useState('');
+  const [optionA, setOptionA] = useState('');
+  const [optionB, setOptionB] = useState('');
+  const [imageA, setImageA] = useState<File | null>(null);
+  const [imageB, setImageB] = useState<File | null>(null);
+  const [explanation, setExplanation] = useState('');
+  const [fieldErrors, setFieldErrors] = useState({
+    question: false,
+    optionA: false,
+    optionB: false,
+    explanation: false,
+  });
+
+  useEffect(() => {
+    if (location.pathname === '/quiz/ab') {
+      setSelectedQuizType('ab');
+    }
+  }, [location.pathname]);
+
+  const handleQuizTypeChange = (selected: string) => {
+    setSelectedQuizType(selected);
+    switch (selected) {
+      case 'ox':
+        navigate('/quiz/ox');
+        break;
+      case 'ab':
+        navigate('/quiz/ab');
+        break;
+      case 'multiple':
+        navigate('/quiz/multiple');
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>, option: 'A' | 'B') => {
+    if (e.target.files && e.target.files[0]) {
+      if (option === 'A') {
+        setImageA(e.target.files[0]);
+      } else {
+        setImageB(e.target.files[0]);
+      }
+    }
+  };
+
+  const removeImage = (option: 'A' | 'B') => {
+    if (option === 'A') {
+      setImageA(null);
+    } else {
+      setImageB(null);
+    }
+  };
+
+  const handleSubmit = () => {
+    const updatedErrors = {
+      question: question.trim() === '',
+      optionA: optionA.trim() === '',
+      optionB: optionB.trim() === '',
+      explanation: explanation.trim() === '',
+    };
+
+    setFieldErrors(updatedErrors);
+
+    if (
+      !updatedErrors.question &&
+      !updatedErrors.optionA &&
+      !updatedErrors.optionB &&
+      !updatedErrors.explanation
+    ) {
+      console.log({ question, optionA, imageA, optionB, imageB, explanation });
+    }
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="퀴즈 만들기" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="퀴즈 유형" htmlFor="quiz-type" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="OX 퀴즈"
+                checked={selectedQuizType === 'ox'}
+                onChange={() => handleQuizTypeChange('ox')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="disabled"
+                title="AB 테스트"
+                checked={selectedQuizType === 'ab'}
+                onChange={() => handleQuizTypeChange('ab')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="객관식"
+                checked={selectedQuizType === 'multiple'}
+                onChange={() => handleQuizTypeChange('multiple')}
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <Label content="문제" htmlFor="quiz-question" className="mb-1" />
+            <TextArea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.question ? 'error' : 'enable'}
+            />
+          </div>
+          <div className="mb-4">
+            <div className="mb-2">
+              <Label content="A 선택지" htmlFor="option-a" className="mb-1" />
+              <TextField
+                mode="outlined"
+                onChange={(e) => setOptionA(e.target.value)}
+                placeholder="A 선택지를 입력하세요."
+                size="M"
+                state={fieldErrors.optionA ? 'error' : 'enable'}
+                value={optionA}
+              />
+            </div>
+            <Label content="A 이미지 첨부" htmlFor="image-a" className="mb-1" />
+            <input
+              id="image-a"
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleImageChange(e, 'A')}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            {imageA && (
+              <div className="relative mt-2">
+                <img
+                  src={URL.createObjectURL(imageA)}
+                  alt="A 선택지 이미지"
+                  className="w-full h-full object-cover rounded border"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage('A')}
+                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                >
+                  <Icon icon="close" size={48} />
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="mb-4">
+            <div className="mb-2">
+              <Label content="B 선택지" htmlFor="option-b" className="mb-1" />
+              <TextField
+                mode="outlined"
+                onChange={(e) => setOptionB(e.target.value)}
+                placeholder="B 선택지를 입력하세요."
+                size="M"
+                state={fieldErrors.optionB ? 'error' : 'enable'}
+                value={optionB}
+              />
+            </div>
+            <Label content="B 이미지 첨부" htmlFor="image-b" className="mb-1" />
+            <input
+              id="image-b"
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleImageChange(e, 'B')}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            {imageB && (
+              <div className="relative mt-2">
+                <img
+                  src={URL.createObjectURL(imageB)}
+                  alt="B 선택지 이미지"
+                  className="w-full h-full object-cover rounded border"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage('B')}
+                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                >
+                  <Icon icon="close" size={48} />
+                </button>
+              </div>
+            )}
+          </div>
+          <Label content="해설" htmlFor="explanation" className="mb-1" />
+          <TextArea
+            value={explanation}
+            onChange={(e) => setExplanation(e.target.value)}
+            placeholder="해설을 입력하세요."
+            size="M"
+            state={fieldErrors.explanation ? 'error' : 'enable'}
+          />
+        </Card>
+        <ShadcnButton className="w-full h-12 text-lg" size="default" onClick={handleSubmit}>
+          퀴즈 생성하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/MultipleChoicePage.tsx
+++ b/src/pages/quiz/MultipleChoicePage.tsx
@@ -127,7 +127,7 @@ export default function MultipleChoicePage() {
               <Radio
                 alert="퀴즈 유형을 선택해주세요."
                 size="M"
-                state="readonly"
+                state="disabled"
                 title="객관식"
                 checked={selectedQuizType === 'multiple'}
                 onChange={() => handleQuizTypeChange('multiple')}

--- a/src/pages/quiz/MultipleChoicePage.tsx
+++ b/src/pages/quiz/MultipleChoicePage.tsx
@@ -1,0 +1,222 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import TextField from '@eolluga/eolluga-ui/Input/TextField';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+export default function MultipleChoicePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [selectedQuizType, setSelectedQuizType] = useState('');
+  const [selectedAnswer, setSelectedAnswer] = useState<number>(1); // 기본 정답값을 1로 설정 (error 처리시 화면 규격 이상해짐)
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<string[]>(['', '', '', '']);
+  const [explanation, setExplanation] = useState('');
+  const [images, setImages] = useState<File[]>([]);
+  const [fieldErrors, setFieldErrors] = useState({
+    question: false,
+    options: [false, false, false, false],
+    explanation: false,
+  });
+
+  // URL에 따라 선택된 퀴즈 유형 설정
+  useEffect(() => {
+    if (location.pathname === '/quiz/multiple') {
+      setSelectedQuizType('multiple');
+    } else if (location.pathname === '/quiz/ox') {
+      setSelectedQuizType('ox');
+    } else if (location.pathname === '/quiz/ab') {
+      setSelectedQuizType('ab');
+    }
+  }, [location.pathname]);
+
+  // 퀴즈 유형 변경 시 URL 변경
+  const handleQuizTypeChange = (selected: string) => {
+    setSelectedQuizType(selected);
+    switch (selected) {
+      case 'ox':
+        navigate('/quiz/ox');
+        break;
+      case 'ab':
+        navigate('/quiz/ab');
+        break;
+      case 'multiple':
+        navigate('/quiz/multiple');
+        break;
+      default:
+        break;
+    }
+  };
+  // 정답 선택 시 정답값 변경
+  const handleAnswerChange = (answer: number) => {
+    setSelectedAnswer(answer);
+  };
+  // 선택지 입력 시 입력값 변경
+  const handleOptionChange = (index: number, value: string) => {
+    const updatedOptions = [...options];
+    updatedOptions[index] = value;
+    setOptions(updatedOptions);
+
+    const updatedErrors = [...fieldErrors.options];
+    updatedErrors[index] = value.trim() === '';
+    setFieldErrors((prev) => ({ ...prev, options: updatedErrors }));
+  };
+  // 이미지 첨부
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const files = Array.from(e.target.files);
+      const newImages = [...images, ...files].slice(0, 4); // 최대 4개까지 제한
+      setImages(newImages);
+    }
+  };
+  // 이미지 삭제
+  const removeImage = (index: number) => {
+    const updatedImages = images.filter((_, i) => i !== index);
+    setImages(updatedImages);
+  };
+  // 퀴즈 생성 시 입력값이 없다면 에러 처리를 위한 함수 => 에러처리되면 state가 enable에서 error로 변경
+  const handleSubmit = () => {
+    const updatedErrors = {
+      question: question.trim() === '',
+      options: options.map((option) => option.trim() === ''),
+      explanation: explanation.trim() === '',
+    };
+
+    setFieldErrors(updatedErrors);
+
+    if (
+      !updatedErrors.question &&
+      !updatedErrors.options.some((err) => err) &&
+      !updatedErrors.explanation
+    ) {
+      console.log({ question, options, selectedAnswer, explanation, images });
+    }
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="퀴즈 만들기" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="퀴즈 유형" htmlFor="quiz-type" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="OX 퀴즈"
+                checked={selectedQuizType === 'ox'}
+                onChange={() => handleQuizTypeChange('ox')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="AB 테스트"
+                checked={selectedQuizType === 'ab'}
+                onChange={() => handleQuizTypeChange('ab')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readonly"
+                title="객관식"
+                checked={selectedQuizType === 'multiple'}
+                onChange={() => handleQuizTypeChange('multiple')}
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <Label content="문제" htmlFor="quiz-question" className="mb-1" />
+            <TextArea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.question ? 'error' : 'enable'}
+            />
+          </div>
+          <div className="mb-4">
+            <Label content="이미지 첨부 (최대 4개)" htmlFor="quiz-images" className="mb-1" />
+            <input
+              id="quiz-images"
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleImageChange}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            <div className="grid grid-cols-4 gap-2 mt-2">
+              {images.map((image, index) => (
+                <div key={index} className="relative">
+                  <img
+                    src={URL.createObjectURL(image)}
+                    alt={`Uploaded ${index + 1}`}
+                    className="w-full h-20 object-cover rounded border"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(index)}
+                    className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                  >
+                    <Icon icon="close" size={48} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="mb-4">
+            {['1번 선택지', '2번 선택지', '3번 선택지', '4번 선택지'].map((label, index) => (
+              <div key={index} className="mb-2">
+                <Label content={label} htmlFor={`option-${index + 1}`} className="mb-1" />
+                <TextField
+                  mode="outlined"
+                  onChange={(e) => handleOptionChange(index, e.target.value)}
+                  placeholder={`${label}를 입력하세요.`}
+                  size="M"
+                  state={fieldErrors.options[index] ? 'error' : 'enable'}
+                  value={options[index]}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mb-4">
+            <Label content="정답" htmlFor="answer" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              {options.map((_, index) => (
+                <Radio
+                  key={index}
+                  alert="정답을 선택해주세요."
+                  size="M"
+                  state="enable"
+                  title={`${index + 1}`}
+                  checked={selectedAnswer === index + 1}
+                  onChange={() => handleAnswerChange(index + 1)}
+                />
+              ))}
+            </div>
+          </div>
+          <Label content="해설" htmlFor="explanation" className="mb-1" />
+          <TextArea
+            value={explanation}
+            onChange={(e) => setExplanation(e.target.value)}
+            placeholder="해설을 입력하세요."
+            size="M"
+            state={fieldErrors.explanation ? 'error' : 'enable'}
+          />
+        </Card>
+        <ShadcnButton className="w-full h-12 text-lg" size="default" onClick={handleSubmit}>
+          퀴즈 생성하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/OxPage.tsx
+++ b/src/pages/quiz/OxPage.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+export default function OXQuizPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [selectedQuizType, setSelectedQuizType] = useState('');
+  const [selectedAnswer, setSelectedAnswer] = useState<string>('O'); // 기본 정답값을 O로 설정
+  const [question, setQuestion] = useState('');
+  const [explanation, setExplanation] = useState('');
+  const [image, setImage] = useState<File | null>(null);
+  const [fieldErrors, setFieldErrors] = useState({
+    question: false,
+    explanation: false,
+  });
+
+  useEffect(() => {
+    if (location.pathname === '/quiz/ox') {
+      setSelectedQuizType('ox');
+    }
+  }, [location.pathname]);
+
+  const handleQuizTypeChange = (selected: string) => {
+    setSelectedQuizType(selected);
+    switch (selected) {
+      case 'ox':
+        navigate('/quiz/ox');
+        break;
+      case 'ab':
+        navigate('/quiz/ab');
+        break;
+      case 'multiple':
+        navigate('/quiz/multiple');
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleAnswerChange = (answer: string) => {
+    setSelectedAnswer(answer);
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setImage(e.target.files[0]);
+    }
+  };
+
+  const removeImage = () => {
+    setImage(null);
+  };
+
+  const handleSubmit = () => {
+    const updatedErrors = {
+      question: question.trim() === '',
+      explanation: explanation.trim() === '',
+    };
+
+    setFieldErrors(updatedErrors);
+
+    if (!updatedErrors.question && !updatedErrors.explanation) {
+      console.log({ question, selectedAnswer, explanation, image });
+    }
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="퀴즈 만들기" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="퀴즈 유형" htmlFor="quiz-type" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="disabled"
+                title="OX 퀴즈"
+                checked={selectedQuizType === 'ox'}
+                onChange={() => handleQuizTypeChange('ox')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="AB 테스트"
+                checked={selectedQuizType === 'ab'}
+                onChange={() => handleQuizTypeChange('ab')}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="enable"
+                title="객관식"
+                checked={selectedQuizType === 'multiple'}
+                onChange={() => handleQuizTypeChange('multiple')}
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <Label content="문제" htmlFor="quiz-question" className="mb-1" />
+            <TextArea
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.question ? 'error' : 'enable'}
+            />
+          </div>
+          <div className="mb-4">
+            <Label content="이미지 첨부 (최대 1개)" htmlFor="quiz-image" className="mb-1" />
+            <input
+              id="quiz-image"
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            {image && (
+              <div className="relative mt-2">
+                <img
+                  src={URL.createObjectURL(image)}
+                  alt="Uploaded"
+                  className="w-full h-full object-cover rounded border"
+                />
+                <button
+                  type="button"
+                  onClick={removeImage}
+                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
+                >
+                  <Icon icon="close" size={48} />
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="mb-4">
+            <Label content="정답" htmlFor="answer" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="정답을 선택해주세요."
+                size="M"
+                state="enable"
+                title="O"
+                checked={selectedAnswer === 'O'}
+                onChange={() => handleAnswerChange('O')}
+              />
+              <Radio
+                alert="정답을 선택해주세요."
+                size="M"
+                state="enable"
+                title="X"
+                checked={selectedAnswer === 'X'}
+                onChange={() => handleAnswerChange('X')}
+              />
+            </div>
+          </div>
+          <Label content="해설" htmlFor="explanation" className="mb-1" />
+          <TextArea
+            value={explanation}
+            onChange={(e) => setExplanation(e.target.value)}
+            placeholder="해설을 입력하세요."
+            size="M"
+            state={fieldErrors.explanation ? 'error' : 'enable'}
+          />
+        </Card>
+        <ShadcnButton className="w-full h-12 text-lg" size="default" onClick={handleSubmit}>
+          퀴즈 생성하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/index.ts
+++ b/src/pages/quiz/index.ts
@@ -1,0 +1,3 @@
+export { default as AbPage } from './AbPage';
+export { default as OxPage } from './OxPage';
+export { default as MultipleChoicePage } from './MultipleChoicePage';


### PR DESCRIPTION
일단 완성시키는걸 목적으로 하다보니 코드가 더러운데 이건 수정까지 만들고 리팩토링 해보겠습니다.
각 퀴즈별로 타입을 다르게 설정했는데 타입을 통일시키면 불필요한 필드가 생기고 데이터 검증이 복잡해질 것 같아서 다르게 했습니다.

| OX퀴즈 | AB테스트 | 객관식 |
|---------|---------|---------|
| ![image1](https://github.com/user-attachments/assets/539ae956-bba2-46f3-ae30-a21745766fbe) | ![image2](https://github.com/user-attachments/assets/5a2bae40-68ed-4248-a0a7-3e12bb27c1a0) | ![image3](https://github.com/user-attachments/assets/2fe5d197-ac34-4375-948b-a4dc664d0c9c) |




