### PR TITLE
[Feat]: API response에 맞게 타입, 더미데이터, 퀴즈 컴포넌트 수정

### DIFF
--- a/src/components/Quiz/QuizAB.tsx
+++ b/src/components/Quiz/QuizAB.tsx
@@ -1,53 +1,44 @@
 import { useState } from 'react';
-import type { QuizAB as QuizABType } from '@/types';
+import type { BaseQuizAPI } from '@/types';
 
-function QuizAB({ quiz }: { quiz: QuizABType }) {
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+function QuizAB({ quiz }: { quiz: BaseQuizAPI }) {
+  const [selectedOption, setSelectedOption] = useState<number | null>(null);
 
-  // 임시 선택 비율
-  const mockPercentages = {
-    optionA: { percentage: 60, count: 61 },
-    optionB: { percentage: 40, count: 40 },
-  };
-
-  const handleOptionClick = (option: string) => {
-    if (selectedOption) return;
-    setSelectedOption(option);
+  const handleOptionClick = (optionNo: number) => {
+    if (selectedOption !== null) return;
+    setSelectedOption(optionNo);
   };
 
   return (
     <div>
-      <h3 className="text-lg font-semibold mb-4">{quiz.question}</h3>
+      <h3 className="text-lg font-semibold mb-4">{quiz.content}</h3>
       <div className="space-y-4">
-        {quiz.options.map((option, index) => {
+        {quiz.options.map((option) => {
           const isSelected = selectedOption !== null;
-          const isOptionA = option === quiz.options[0];
-          const percentage = isOptionA
-            ? mockPercentages.optionA.percentage
-            : mockPercentages.optionB.percentage;
-          const count = isOptionA ? mockPercentages.optionA.count : mockPercentages.optionB.count;
+          const isCurrentOption = selectedOption === option.no;
 
           return (
             <div
-              key={index}
+              key={option.no}
               className={`p-4 rounded-lg border text-sm font-medium cursor-pointer ${
                 !isSelected ? 'hover:bg-gray-100' : ''
               }`}
-              onClick={() => handleOptionClick(option)}
+              onClick={() => handleOptionClick(option.no)}
               style={{
                 background: isSelected
                   ? `linear-gradient(to right, ${
-                      isOptionA ? '#FBBF24' : '#E5E7EB'
-                    } ${percentage}%, #FFFFFF ${percentage}%)`
+                      isCurrentOption ? '#FBBF24' : '#E5E7EB'
+                    } ${option.selectionRatio * 100}%, #FFFFFF ${option.selectionRatio * 100}%)`
                   : '',
-                color: isSelected ? (isOptionA ? '#FFFFFF' : '#6B7280') : '#000000',
-                borderColor: isSelected ? (isOptionA ? '#FBBF24' : '#E5E7EB') : '#D1D5DB',
+                color: isSelected ? (isCurrentOption ? '#FFFFFF' : '#6B7280') : '#000000',
+                borderColor: isSelected ? (isCurrentOption ? '#FBBF24' : '#E5E7EB') : '#D1D5DB',
               }}
             >
-              {option}{' '}
+              {option.content}{' '}
               {isSelected && (
                 <span className="ml-2 font-semibold">
-                  {percentage}% ({count}명)
+                  {(option.selectionRatio * 100).toFixed(1)}% (
+                  {Math.round(option.selectionRatio * 100)}명)
                 </span>
               )}
             </div>

--- a/src/components/Quiz/QuizAB.tsx
+++ b/src/components/Quiz/QuizAB.tsx
@@ -14,28 +14,29 @@ function QuizAB({ quiz }: { quiz: BaseQuizAPI }) {
       <h3 className="text-lg font-semibold mb-4">{quiz.content}</h3>
       <div className="space-y-4">
         {quiz.options.map((option) => {
-          const isSelected = selectedOption !== null;
           const isCurrentOption = selectedOption === option.no;
 
           return (
             <div
               key={option.no}
               className={`p-4 rounded-lg border text-sm font-medium cursor-pointer ${
-                !isSelected ? 'hover:bg-gray-100' : ''
+                selectedOption === null ? 'hover:bg-gray-100' : ''
               }`}
               onClick={() => handleOptionClick(option.no)}
               style={{
-                background: isSelected
-                  ? `linear-gradient(to right, ${
-                      isCurrentOption ? '#FBBF24' : '#E5E7EB'
-                    } ${option.selectionRatio * 100}%, #FFFFFF ${option.selectionRatio * 100}%)`
-                  : '',
-                color: isSelected ? (isCurrentOption ? '#FFFFFF' : '#6B7280') : '#000000',
-                borderColor: isSelected ? (isCurrentOption ? '#FBBF24' : '#E5E7EB') : '#D1D5DB',
+                background:
+                  selectedOption !== null
+                    ? `linear-gradient(to right, ${
+                        isCurrentOption ? '#FDBA94' : '#FEF2EA'
+                      } ${option.selectionRatio * 100}%, #FFFFFF ${option.selectionRatio * 100}%)`
+                    : '',
+                color: selectedOption !== null && !isCurrentOption ? '#6B7280' : '#000000',
+                borderColor:
+                  selectedOption !== null ? (isCurrentOption ? '#FDBA94' : '#E5E7EB') : '#D1D5DB',
               }}
             >
-              {option.content}{' '}
-              {isSelected && (
+              {option.content}
+              {selectedOption !== null && (
                 <span className="ml-2 font-semibold">
                   {(option.selectionRatio * 100).toFixed(1)}% (
                   {Math.round(option.selectionRatio * 100)}명)

--- a/src/components/Quiz/QuizFooter.tsx
+++ b/src/components/Quiz/QuizFooter.tsx
@@ -1,9 +1,8 @@
-import type { Comment } from '@/types';
 import Icon from '@eolluga/eolluga-ui/icon/Icon';
 
 interface QuizFooterProps {
   likes: number;
-  comments: Comment[];
+  comments: number;
   isLiked: boolean;
   onToggleLike: () => void;
   onCommentsClick: () => void;
@@ -19,7 +18,7 @@ function QuizFooter({ likes, comments, isLiked, onToggleLike, onCommentsClick }:
 
       <button className="flex items-center" onClick={onCommentsClick} aria-label="댓글">
         <Icon icon="chat" />
-        <span className="ml-1">{comments.length}</span>
+        <span className="ml-1">{comments}</span>
       </button>
     </div>
   );

--- a/src/components/Quiz/QuizMul.tsx
+++ b/src/components/Quiz/QuizMul.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import type { QuizMul as QuizMulType } from '@/types';
+import type { BaseQuizAPI } from '@/types';
 import { Button } from '../common/Button';
 
 interface QuizMulProps {
-  quiz: QuizMulType;
+  quiz: BaseQuizAPI;
   onAnswerSelect: (answer: string) => void;
 }
 
@@ -11,36 +11,36 @@ function QuizMul({ quiz, onAnswerSelect }: QuizMulProps) {
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [, setIsCorrect] = useState<boolean | null>(null);
 
-  const handleAnswerSelect = (option: string) => {
+  const handleAnswerSelect = (optionContent: string) => {
     if (selectedAnswer) return;
-    setSelectedAnswer(option);
-    setIsCorrect(option === quiz.correctAnswer);
-    onAnswerSelect(option);
+    setSelectedAnswer(optionContent);
+    setIsCorrect(optionContent === quiz.answer.content);
+    onAnswerSelect(optionContent);
   };
 
   return (
     <div>
-      <h3 className="text-lg font-semibold">{quiz.question}</h3>
+      <h3 className="text-lg font-semibold">{quiz.content}</h3>
       <ul className="space-y-2 mt-4">
-        {quiz.options.map((option, index) => {
+        {quiz.options.map((option) => {
           let color: '#A0E2B0' | '#FAA4A3' | 'gray' = 'gray';
           let variant: 'fill' | 'unfill' = 'unfill';
 
           if (selectedAnswer) {
-            if (option === quiz.correctAnswer) {
+            if (option.content === quiz.answer.content) {
               color = '#A0E2B0';
               variant = 'fill';
-            } else if (option === selectedAnswer) {
+            } else if (option.content === selectedAnswer) {
               color = '#FAA4A3';
               variant = 'fill';
             }
           }
 
           return (
-            <li key={index}>
+            <li key={option.no}>
               <Button
-                label={option}
-                onClick={() => handleAnswerSelect(option)}
+                label={option.content}
+                onClick={() => handleAnswerSelect(option.content)}
                 color={color}
                 variant={variant}
                 size="long"

--- a/src/components/Quiz/QuizOX.tsx
+++ b/src/components/Quiz/QuizOX.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import type { QuizOX as QuizOXType } from '@/types';
+import type { BaseQuizAPI } from '@/types';
 import { Button } from '../common/Button';
 
 interface QuizOXProps {
-  quiz: QuizOXType;
+  quiz: BaseQuizAPI;
   onAnswerSelect: (answer: string) => void;
 }
 
@@ -14,13 +14,13 @@ function QuizOX({ quiz, onAnswerSelect }: QuizOXProps) {
   const handleAnswerSelect = (answer: string) => {
     if (selectedAnswer) return;
     setSelectedAnswer(answer);
-    setIsCorrect(answer === quiz.correctAnswer);
+    setIsCorrect(answer === quiz.answer.content);
     onAnswerSelect(answer);
   };
 
   return (
     <div>
-      <h3 className="text-lg font-semibold mb-4">{quiz.question}</h3>
+      <h3 className="text-lg font-semibold mb-4">{quiz.content}</h3>
       <div className="flex space-x-2">
         <Button
           label="O"
@@ -32,7 +32,13 @@ function QuizOX({ quiz, onAnswerSelect }: QuizOXProps) {
         <Button
           label="X"
           onClick={() => handleAnswerSelect('X')}
-          color={selectedAnswer === 'X' ? (isCorrect ? '#A0E2B0' : '#FAA4A3') : 'gray'}
+          color={
+            selectedAnswer === 'X'
+              ? isCorrect
+                ? '#A0E2B0'
+                : '#FAA4A3'
+              : 'gray'
+          }
           variant={selectedAnswer === 'X' ? 'fill' : 'unfill'}
           size="long"
         />

--- a/src/components/Quiz/QuizRenderer.tsx
+++ b/src/components/Quiz/QuizRenderer.tsx
@@ -1,0 +1,20 @@
+import { BaseQuizAPI } from '@/types';
+import { QuizAB, QuizMul, QuizOX } from '.';
+
+interface QuizRendererProps {
+  quiz: BaseQuizAPI;
+  onAnswerSelect: (answer: string) => void;
+}
+
+const QuizRenderer = ({ quiz, onAnswerSelect }: QuizRendererProps) => {
+  if (quiz.type === 'OX 퀴즈') {
+    return <QuizOX quiz={quiz} onAnswerSelect={onAnswerSelect} />;
+  } else if (quiz.type === 'ABTest') {
+    return <QuizAB quiz={quiz} />;
+  } else if (quiz.type === '객관식') {
+    return <QuizMul quiz={quiz} onAnswerSelect={onAnswerSelect} />;
+  }
+  return null;
+};
+
+export default QuizRenderer;

--- a/src/components/Quiz/QuizWrapper.tsx
+++ b/src/components/Quiz/QuizWrapper.tsx
@@ -1,10 +1,9 @@
 import { BaseQuizAPI } from '@/types';
 import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useState } from 'react';
-import { QuizAB, QuizAns, QuizFooter, QuizMul, QuizOX } from '.';
+import { QuizAns, QuizFooter, QuizRenderer } from '.';
 import BottomSheet from '../common/BottomSheet';
-import { dummyComments } from '@/data/dummyComment';
-import { Comment } from '@/types';
+import { useComments } from '@/hooks';
 
 interface QuizWrapperProps {
   quiz: BaseQuizAPI;
@@ -19,22 +18,7 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
 
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [loadingComments, setLoadingComments] = useState(false);
-
-  const fetchComments = async (quizId: number) => {
-    setLoadingComments(true);
-    setComments([]);
-
-    // 더미 데이터에서 해당 퀴즈 ID에 맞는 댓글 가져오기
-    const response = dummyComments.filter((comment) => comment.quizId === quizId);
-
-    // 임의의 딜레이 추가 (로딩 효과를 모방)
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    setComments(response);
-    setLoadingComments(false);
-  };
+  const { comments, loading, fetchComments } = useComments();
 
   const handleCommentsClick = () => {
     setBottomSheetOpen(true);
@@ -51,17 +35,6 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
     setIsCorrect(answer === quiz.answer.content);
   };
 
-  const renderQuizContent = () => {
-    if (quiz.type === 'OX 퀴즈') {
-      return <QuizOX quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
-    } else if (quiz.type === 'ABTest') {
-      return <QuizAB quiz={quiz} />;
-    } else if (quiz.type === '객관식') {
-      return <QuizMul quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
-    }
-    return null;
-  };
-
   return (
     <div className="flex items-center h-full">
       <div className="w-full p-6 bg-white border border-gray-300 rounded-lg shadow-md">
@@ -72,7 +45,7 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
             <p className="text-sm text-gray-500">{quiz.type}</p>
           </div>
         </div>
-        {renderQuizContent()}
+        <QuizRenderer quiz={quiz} onAnswerSelect={handleAnswerSelect} />
         {selectedAnswer !== null && isCorrect !== null && (
           <QuizAns isCorrect={isCorrect} explanation={quiz.answer.explanation} />
         )}
@@ -88,7 +61,7 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
         isOpen={isBottomSheetOpen}
         setOpen={setBottomSheetOpen}
         comments={comments}
-        loading={loadingComments}
+        loading={loading}
       />
     </div>
   );

--- a/src/components/Quiz/QuizWrapper.tsx
+++ b/src/components/Quiz/QuizWrapper.tsx
@@ -1,19 +1,45 @@
-import { Quiz } from '@/types';
+import { BaseQuizAPI } from '@/types';
 import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useState } from 'react';
 import { QuizAB, QuizAns, QuizFooter, QuizMul, QuizOX } from '.';
 import BottomSheet from '../common/BottomSheet';
+import { dummyComments } from '@/data/dummyComment';
+import { Comment } from '@/types';
 
 interface QuizWrapperProps {
-  quiz: Quiz;
+  quiz: BaseQuizAPI;
 }
 
 function QuizWrapper({ quiz }: QuizWrapperProps) {
-  const [isLiked, setIsLiked] = useState(false);
-  const [likes, setLikes] = useState(quiz.likes);
-  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [isLiked, setIsLiked] = useState(quiz.liked || false);
+  const [likes, setLikes] = useState(quiz.count.like);
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(
+    quiz.answeredOption ? String(quiz.answeredOption) : null,
+  );
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
+
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loadingComments, setLoadingComments] = useState(false);
+
+  const fetchComments = async (quizId: number) => {
+    setLoadingComments(true);
+    setComments([]);
+
+    // 더미 데이터에서 해당 퀴즈 ID에 맞는 댓글 가져오기
+    const response = dummyComments.filter((comment) => comment.quizId === quizId);
+
+    // 임의의 딜레이 추가 (로딩 효과를 모방)
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    setComments(response);
+    setLoadingComments(false);
+  };
+
+  const handleCommentsClick = () => {
+    setBottomSheetOpen(true);
+    fetchComments(quiz.id);
+  };
 
   const handleToggleLike = () => {
     setIsLiked(!isLiked);
@@ -22,15 +48,15 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
 
   const handleAnswerSelect = (answer: string) => {
     setSelectedAnswer(answer);
-    setIsCorrect(answer === quiz.correctAnswer);
+    setIsCorrect(answer === quiz.answer.content);
   };
 
   const renderQuizContent = () => {
-    if (quiz.type === 'OX') {
+    if (quiz.type === 'OX 퀴즈') {
       return <QuizOX quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
     } else if (quiz.type === 'ABTest') {
       return <QuizAB quiz={quiz} />;
-    } else if (quiz.type === 'MultipleChoice') {
+    } else if (quiz.type === '객관식') {
       return <QuizMul quiz={quiz} onAnswerSelect={handleAnswerSelect} />;
     }
     return null;
@@ -40,30 +66,29 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
     <div className="flex items-center h-full">
       <div className="w-full p-6 bg-white border border-gray-300 rounded-lg shadow-md">
         <div className="flex items-center mb-4">
-          <Avatar size="S" />
+          <Avatar size="S" image={quiz.avatarUrl || '/default-avatar.png'} />
           <div className="ml-4">
-            <h4 className="text-md font-bold">{quiz.author}</h4>
-            <p className="text-sm text-gray-500">
-              {quiz.type === 'OX' ? 'OX 퀴즈' : quiz.type === 'ABTest' ? 'A/B 테스트' : '객관식'}
-            </p>
+            <h4 className="text-md font-bold">{quiz.author || 'default'}</h4>
+            <p className="text-sm text-gray-500">{quiz.type}</p>
           </div>
         </div>
         {renderQuizContent()}
         {selectedAnswer !== null && isCorrect !== null && (
-          <QuizAns isCorrect={isCorrect} explanation={quiz.explanation} />
+          <QuizAns isCorrect={isCorrect} explanation={quiz.answer.explanation} />
         )}
         <QuizFooter
           likes={likes}
-          comments={quiz.comments}
+          comments={quiz.count.comment}
           isLiked={isLiked}
           onToggleLike={handleToggleLike}
-          onCommentsClick={() => setBottomSheetOpen(true)}
+          onCommentsClick={handleCommentsClick}
         />
       </div>
       <BottomSheet
         isOpen={isBottomSheetOpen}
         setOpen={setBottomSheetOpen}
-        comments={quiz.comments}
+        comments={comments}
+        loading={loadingComments}
       />
     </div>
   );

--- a/src/components/Quiz/index.ts
+++ b/src/components/Quiz/index.ts
@@ -4,3 +4,4 @@ export { default as QuizFooter } from './QuizFooter';
 export { default as QuizMul } from './QuizMul';
 export { default as QuizOX } from './QuizOX';
 export { default as QuizWrapper } from './QuizWrapper';
+export { default as QuizRenderer } from './QuizRenderer';

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -15,9 +15,10 @@ type BottomSheetProps = {
   isOpen: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   comments: Comment[];
+  loading: boolean;
 };
 
-export default function BottomSheet({ isOpen, setOpen, comments }: BottomSheetProps) {
+export default function BottomSheet({ isOpen, setOpen, comments, loading }: BottomSheetProps) {
   const [inputValue, setInputValue] = useState<string>('');
   //const [sortOption, setSortOption] = useState<string>('최신 순'); // 정렬 옵션 상태
 
@@ -50,15 +51,34 @@ export default function BottomSheet({ isOpen, setOpen, comments }: BottomSheetPr
         </DrawerHeader>
 
         <div className="flex flex-col space-y-4 justify-between overflow-y-scroll">
-          <div className="p-4">
-            {comments.length > 0 ? (
+          <div className="overflow-y-auto p-4">
+            {loading ? (
+              <div className="flex justify-center items-center h-full">
+                <span className="text-gray-500">로딩 중...</span>
+              </div>
+            ) : comments.length > 0 ? (
               comments.map((comment) => (
-                <div key={comment.id} className="mb-4 flex items-start gap-3 border-b pb-2">
-                  <Avatar size="S" />
-                  <div>
-                    <div className="text-sm font-bold">{comment.author}</div>
-                    <p className="text-sm text-gray-600">{comment.content}</p>
+                <div key={comment.id} className="mb-4 flex flex-col gap-2">
+                  <div className="flex items-start gap-3 border-b pb-2">
+                    <Avatar size="S" />
+                    <div>
+                      <div className="text-sm font-bold">User {comment.writerId}</div>
+                      <p className="text-sm text-gray-600">{comment.content}</p>
+                    </div>
                   </div>
+                  {(comment.childComments || []).length > 0 && (
+                    <div className="ml-8 border-l-2 pl-2">
+                      {(comment.childComments || []).map((childComment) => (
+                        <div key={childComment.id} className="flex items-start gap-3 mb-2">
+                          <Avatar size="S" />
+                          <div>
+                            <div className="text-sm font-bold">User {childComment.writerId}</div>
+                            <p className="text-sm text-gray-600">{childComment.content}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ))
             ) : (
@@ -68,17 +88,22 @@ export default function BottomSheet({ isOpen, setOpen, comments }: BottomSheetPr
             )}
           </div>
         </div>
-        <div className="w-full border-t-2 sticky bottom-0 pt-4 pb-2 bg-white">
-          <div className="flex px-4 gap-4">
-            <TextField
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              size="M"
-              mode="outlined"
-              placeholder="댓글을 입력하세요"
-            />
-            <div className="p-3 bg-black rounded-xl" onClick={() => console.log('댓글 게시')}>
-              <Icon icon="add" className="fill-white" />
+        <div className="w-full border-t-2 sticky bottom-4 pt-1">
+          <div className="flex px-2">
+            <div className="flex items-center w-full bg-white border border-gray-100 rounded-lg overflow-hidden gap-1">
+              <TextField
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                size="M"
+                mode="outlined"
+                placeholder="댓글을 입력하세요"
+              />
+              <button
+                onClick={() => console.log('댓글 게시')}
+                className="flex items-center justify-center px-2 py-2 bg-black text-white text-sm rounded-sm"
+              >
+                <Icon icon="add" className="fill-white" />
+              </button>
             </div>
           </div>
         </div>

--- a/src/data/dummyComment.ts
+++ b/src/data/dummyComment.ts
@@ -1,0 +1,98 @@
+import { Comment } from '@/types';
+
+export const dummyComments: Comment[] = [
+  // Quiz ID: 1, Comment Count: 3
+  {
+    id: 1,
+    quizId: 1,
+    writerId: 1,
+    parentCommentId: 0,
+    content: 'React는 재미있는 주제네요.',
+    createdAt: '2024-11-20T10:00:00.000Z',
+    updatedAt: '2024-11-20T10:00:00.000Z',
+    childComments: [
+      {
+        id: 2,
+        quizId: 1,
+        writerId: 2,
+        parentCommentId: 1,
+        content: '저도 그렇게 생각합니다!',
+        createdAt: '2024-11-20T11:00:00.000Z',
+        updatedAt: '2024-11-20T11:00:00.000Z',
+      },
+    ],
+  },
+  {
+    id: 3,
+    quizId: 1,
+    writerId: 3,
+    parentCommentId: 0,
+    content: 'Virtual DOM이 항상 빠르지 않은 이유가 궁금합니다.',
+    createdAt: '2024-11-20T12:00:00.000Z',
+    updatedAt: '2024-11-20T12:00:00.000Z',
+  },
+
+  // Quiz ID: 2, Comment Count: 1
+  {
+    id: 4,
+    quizId: 2,
+    writerId: 4,
+    parentCommentId: 0,
+    content: 'Material Design이 더 현대적이라고 생각해요.',
+    createdAt: '2024-11-20T13:00:00.000Z',
+    updatedAt: '2024-11-20T13:00:00.000Z',
+  },
+
+  // Quiz ID: 3, Comment Count: 2
+  {
+    id: 5,
+    quizId: 3,
+    writerId: 5,
+    parentCommentId: 0,
+    content: 'Arrow Functions는 너무 편리합니다.',
+    createdAt: '2024-11-20T14:00:00.000Z',
+    updatedAt: '2024-11-20T14:00:00.000Z',
+    childComments: [
+      {
+        id: 6,
+        quizId: 3,
+        writerId: 6,
+        parentCommentId: 5,
+        content: '맞아요, 특히 이벤트 핸들러에서 유용하죠.',
+        createdAt: '2024-11-20T15:00:00.000Z',
+        updatedAt: '2024-11-20T15:00:00.000Z',
+      },
+    ],
+  },
+
+  // Quiz ID: 4, Comment Count: 1
+  {
+    id: 7,
+    quizId: 4,
+    writerId: 7,
+    parentCommentId: 0,
+    content: 'CSS는 확실히 스타일링 언어죠.',
+    createdAt: '2024-11-20T16:00:00.000Z',
+    updatedAt: '2024-11-20T16:00:00.000Z',
+  },
+
+  // Quiz ID: 5, Comment Count: 2
+  {
+    id: 8,
+    quizId: 5,
+    writerId: 8,
+    parentCommentId: 0,
+    content: 'Bottom Navigation이 모바일에 더 적합해 보여요.',
+    createdAt: '2024-11-20T17:00:00.000Z',
+    updatedAt: '2024-11-20T17:00:00.000Z',
+  },
+  {
+    id: 9,
+    quizId: 5,
+    writerId: 9,
+    parentCommentId: 0,
+    content: 'Sidebar Navigation은 정보가 많은 경우 더 좋아요.',
+    createdAt: '2024-11-20T18:00:00.000Z',
+    updatedAt: '2024-11-20T18:00:00.000Z',
+  },
+];

--- a/src/data/dummyQuiz.ts
+++ b/src/data/dummyQuiz.ts
@@ -1,105 +1,104 @@
-import { Quiz } from '@/types';
+import { BaseQuizAPI } from '@/types';
 
-export const dummyQuiz: Quiz[] = [
+export const dummyQuizzes: BaseQuizAPI[] = [
   {
     id: 1,
-    type: 'OX',
+    content: 'React의 Virtual DOM은 항상 빠릅니까?',
+    type: 'OX 퀴즈',
     author: 'React Expert',
-    authorAvatar: 'avatarUrl',
-    question: 'React의 Virtual DOM은 실제 DOM보다 항상 빠릅니까?',
-    correctAnswer: 'X',
-    explanation: 'Virtual DOM이 항상 빠른 것은 아닙니다.',
-    likes: 120,
-    comments: [
-      { id: 1, author: 'User1', authorAvatar: 'commentAvatarUrl1', content: '쉬워요' },
-      { id: 2, author: 'User2', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
-      { id: 3, author: 'User3', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
-      { id: 4, author: 'User4', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
-      { id: 5, author: 'User5', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
-      { id: 6, author: 'User6', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
-      { id: 7, author: 'User7', authorAvatar: 'commentAvatarUrl2', content: '배워갑니다.' },
+    avatarUrl: 'avatarUrl',
+    options: [
+      { no: 1, content: 'O', selectionRatio: 0.34 },
+      { no: 2, content: 'X', selectionRatio: 0.66 },
     ],
+    answer: {
+      content: 'X',
+      explanation: 'Virtual DOM이 항상 빠른 것은 아닙니다.',
+    },
+    answeredOption: 2,
+    count: {
+      like: 120,
+      comment: 3,
+    },
+    liked: true,
   },
   {
     id: 2,
+    content: '어떤 버튼 디자인이 더 좋으신가요?',
     type: 'ABTest',
     author: 'UI Designer',
-    authorAvatar: 'avatarUrl2',
-    question: '어떤 버튼 디자인이 더 좋으신가요?',
-    options: ['Flat Design', 'Material Design'],
-    correctAnswer: null,
-    explanation: '',
-    likes: 80,
-    comments: [],
+    avatarUrl: 'avatarUrl',
+    options: [
+      { no: 1, content: 'Flat Design', selectionRatio: 0.42 },
+      { no: 2, content: 'Material Design', selectionRatio: 0.58 },
+    ],
+    answer: {
+      content: '',
+      explanation: '',
+    },
+    count: {
+      like: 80,
+      comment: 1,
+    },
+    liked: false,
   },
   {
     id: 3,
-    type: 'MultipleChoice',
-    author: 'Quiz Master',
-    authorAvatar: 'avatarUrl3',
-    question: 'JavaScript에서 가장 널리 사용되는 ES6 기능은 무엇입니까?',
-    options: ['Arrow Functions', 'Classes', 'Modules', 'Template Literals'],
-    correctAnswer: 'Arrow Functions',
-    explanation: 'Arrow Functions는 간결하고 강력합니다.',
-    likes: 95,
-    comments: [
-      {
-        id: 1,
-        author: 'User1',
-        authorAvatar: 'commentAvatarUrl3',
-        content: '어려워요.',
-      },
+    content: 'JavaScript에서 가장 널리 사용되는 ES6 기능은 무엇입니까?',
+    type: '객관식',
+    options: [
+      { no: 1, content: 'Arrow Functions', selectionRatio: 0.55 },
+      { no: 2, content: 'Classes', selectionRatio: 0.25 },
+      { no: 3, content: 'Modules', selectionRatio: 0.15 },
+      { no: 4, content: 'Template Literals', selectionRatio: 0.05 },
     ],
+    answer: {
+      content: 'Arrow Functions',
+      explanation: 'Arrow Functions는 간결하고 강력합니다.',
+    },
+    answeredOption: 1,
+    count: {
+      like: 95,
+      comment: 2,
+    },
+    liked: true,
   },
   {
     id: 4,
-    type: 'OX',
-    author: 'Web Dev',
-    authorAvatar: 'avatarUrl4',
-    question: 'CSS는 프로그래밍 언어입니까?',
-    correctAnswer: 'X',
-    explanation: 'CSS는 스타일링 언어로, 프로그래밍 언어로 간주되지 않습니다.',
-    likes: 50,
-    comments: [
-      { id: 1, author: 'User3', authorAvatar: 'commentAvatarUrl4', content: '이건 쉬웠어요.' },
+    content: 'CSS는 프로그래밍 언어입니까?',
+    type: 'OX 퀴즈',
+    options: [
+      { no: 1, content: 'O', selectionRatio: 0.15 },
+      { no: 2, content: 'X', selectionRatio: 0.85 },
     ],
+    answer: {
+      content: 'X',
+      explanation: 'CSS는 스타일링 언어로, 프로그래밍 언어로 간주되지 않습니다.',
+    },
+    count: {
+      like: 50,
+      comment: 1,
+    },
+    liked: false,
   },
   {
     id: 5,
+    content: '모바일 네비게이션에서 더 나은 UI는 무엇인가요?',
     type: 'ABTest',
     author: 'Frontend Developer',
-    authorAvatar: 'avatarUrl5',
-    question: '모바일 네비게이션에서 더 나은 UI는 무엇인가요?',
-    options: ['Bottom Navigation', 'Sidebar Navigation'],
-    correctAnswer: null,
-    explanation: '',
-    likes: 110,
-    comments: [
-      {
-        id: 1,
-        author: 'User4',
-        authorAvatar: 'commentAvatarUrl5',
-        content: 'Bottom Navigation이 더 편리합니다.',
-      },
+    avatarUrl: 'avatarUrl',
+    options: [
+      { no: 1, content: 'Bottom Navigation', selectionRatio: 0.67 },
+      { no: 2, content: 'Sidebar Navigation', selectionRatio: 0.33 },
     ],
-  },
-  {
-    id: 6,
-    type: 'MultipleChoice',
-    author: 'JS Enthusiast',
-    authorAvatar: 'avatarUrl6',
-    question: '다음 중 비동기 처리를 위해 가장 널리 사용되는 JavaScript 기능은 무엇입니까?',
-    options: ['Callbacks', 'Promises', 'Async/Await', 'Generators'],
-    correctAnswer: 'Async/Await',
-    explanation: 'Async/Await는 최신 JavaScript에서 비동기 처리를 간단하고 읽기 쉽게 만듭니다.',
-    likes: 150,
-    comments: [
-      {
-        id: 1,
-        author: 'User5',
-        authorAvatar: 'commentAvatarUrl6',
-        content: '유용한 정보 감사합니다.',
-      },
-    ],
+    answer: {
+      content: '',
+      explanation: '',
+    },
+    count: {
+      like: 110,
+      comment: 2,
+    },
+    liked: true,
   },
 ];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useComments } from './useComments';

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,0 +1,52 @@
+// import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+// import axios from 'axios';
+
+// // 댓글 관련 API를 사용하기 위한 커스텀 훅
+// export const useComments = (quizId: string) => {
+//   const queryClient = useQueryClient();
+
+//   // 1. 댓글 가져오기
+//   const { data: comments, isLoading } = useQuery(['comments', quizId], async () => {
+//     const response = await axios.get(`/api/quizzes/${quizId}/comments`);
+//     return response.data;
+//   });
+
+//   // 2. 댓글 등록
+//   const { mutate: addComment } = useMutation(
+//     async (content: string) => {
+//       await axios.post(`/api/quizzes/${quizId}/comments`, { content });
+//     },
+//     {
+//       onSuccess: () => {
+//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
+//       },
+//     }
+//   );
+
+//   // 3. 댓글 삭제
+//   const { mutate: deleteComment } = useMutation(
+//     async (commentId: number) => {
+//       await axios.delete(`/api/quizzes/${quizId}/comments/${commentId}`);
+//     },
+//     {
+//       onSuccess: () => {
+//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
+//       },
+//     }
+//   );
+
+//   // 4. 댓글 수정
+//   const { mutate: editComment } = useMutation(
+//     async ({ commentId, content }: { commentId: number; content: string }) => {
+//       await axios.put(`/api/quizzes/${quizId}/comments/${commentId}`, { content });
+//     },
+//     {
+//       onSuccess: () => {
+//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
+//       },
+//     }
+//   );
+
+//   return {
+//     comments,
+//     isLoading,

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,52 +1,49 @@
-// import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-// import axios from 'axios';
+import { useState } from 'react';
+import { Comment } from '@/types';
+import { dummyComments } from '@/data/dummyComment';
 
-// // 댓글 관련 API를 사용하기 위한 커스텀 훅
-// export const useComments = (quizId: string) => {
-//   const queryClient = useQueryClient();
+const useComments = () => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(false);
 
-//   // 1. 댓글 가져오기
-//   const { data: comments, isLoading } = useQuery(['comments', quizId], async () => {
-//     const response = await axios.get(`/api/quizzes/${quizId}/comments`);
-//     return response.data;
-//   });
+  const fetchComments = async (quizId: number) => {
+    setLoading(true);
+    setComments([]);
 
-//   // 2. 댓글 등록
-//   const { mutate: addComment } = useMutation(
-//     async (content: string) => {
-//       await axios.post(`/api/quizzes/${quizId}/comments`, { content });
-//     },
-//     {
-//       onSuccess: () => {
-//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
-//       },
-//     }
-//   );
+    const response = dummyComments.filter((comment) => comment.quizId === quizId);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
-//   // 3. 댓글 삭제
-//   const { mutate: deleteComment } = useMutation(
-//     async (commentId: number) => {
-//       await axios.delete(`/api/quizzes/${quizId}/comments/${commentId}`);
-//     },
-//     {
-//       onSuccess: () => {
-//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
-//       },
-//     }
-//   );
+    setComments(response);
+    setLoading(false);
+  };
 
-//   // 4. 댓글 수정
-//   const { mutate: editComment } = useMutation(
-//     async ({ commentId, content }: { commentId: number; content: string }) => {
-//       await axios.put(`/api/quizzes/${quizId}/comments/${commentId}`, { content });
-//     },
-//     {
-//       onSuccess: () => {
-//         queryClient.invalidateQueries(['comments', quizId]); // 댓글 목록 갱신
-//       },
-//     }
-//   );
+  const deleteComment = async (commentId: number) => {
+    setLoading(true);
 
-//   return {
-//     comments,
-//     isLoading,
+    const updatedComments = comments.filter((comment) => comment.id !== commentId);
+    setComments(updatedComments);
+
+    setLoading(false);
+  };
+
+  const editComment = async (commentId: number, newContent: string) => {
+    setLoading(true);
+
+    const updatedComments = comments.map((comment) =>
+      comment.id === commentId ? { ...comment, content: newContent } : comment,
+    );
+    setComments(updatedComments);
+
+    setLoading(false);
+  };
+
+  return {
+    comments,
+    loading,
+    fetchComments,
+    deleteComment,
+    editComment,
+  };
+};
+
+export default useComments;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,7 +4,7 @@ import 'swiper/css/pagination';
 
 import { QuizWrapper } from '@/components';
 import TopBar from '@/components/common/TopBar';
-import { dummyQuiz } from '@/data/dummyQuiz';
+import { dummyQuizzes } from '@/data/dummyQuiz';
 import Container from '@/shared/Container';
 
 const MainPage = () => {
@@ -17,7 +17,7 @@ const MainPage = () => {
           className="quizSwiper"
           style={{ height: 'calc(100vh - 9rem)' }}
         >
-          {dummyQuiz.map((quiz) => (
+          {dummyQuizzes.map((quiz) => (
             <SwiperSlide key={quiz.id}>
               <QuizWrapper quiz={quiz} />
             </SwiperSlide>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,7 +1,7 @@
 import { QuizWrapper, TagList } from '@/components';
 import SearchBar from '@/components/common/SearchBar';
 import TopBar from '@/components/common/TopBar';
-import { dummyQuiz } from '@/data/dummyQuiz';
+import { dummyQuizzes } from '@/data/dummyQuiz';
 import Container from '@/shared/Container';
 
 const SearchPage = () => {
@@ -17,7 +17,7 @@ const SearchPage = () => {
         <SearchBar />
         <TagList tags={tags} onTagClick={handleTagClick} />
 
-        {dummyQuiz.map((quiz) => (
+        {dummyQuizzes.map((quiz) => (
           <QuizWrapper key={quiz.id} quiz={quiz} />
         ))}
       </Container>

--- a/src/types/CommentTypes.ts
+++ b/src/types/CommentTypes.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+  id: number; // 댓글 ID
+  quizId: number; // 해당 퀴즈 ID
+  writerId: number; // 작성자 ID
+  parentCommentId: number; // 부모 댓글 ID (0이면 최상위 댓글)
+  content: string; // 댓글 내용
+  childComments?: Comment[]; // 대댓글 리스트 (없을 수도 있음)
+  createdAt: string; // 생성 시간
+  updatedAt: string; // 수정 시간
+}

--- a/src/types/QuizTypes.ts
+++ b/src/types/QuizTypes.ts
@@ -1,35 +1,28 @@
-export interface Comment {
-  id: number;
-  author: string;
-  authorAvatar: string;
-  content: string;
+export interface QuizOption {
+  no: number; // 옵션 번호
+  content: string; // 옵션 내용
+  selectionRatio: number; // 선택 비율
 }
 
-export interface BaseQuiz {
-  id: number;
-  author: string;
-  authorAvatar: string;
-  question: string;
-  correctAnswer: string | null;
-  explanation: string;
-  likes: number;
-  comments: Comment[];
-  options?: string[];
+export interface QuizAnswer {
+  content: string; // 정답 내용
+  explanation: string; // 정답 해설
 }
 
-export interface QuizOX extends BaseQuiz {
-  type: 'OX';
-  options?: undefined;
+export interface QuizCount {
+  like: number; // 좋아요 수
+  comment: number; // 댓글 수
 }
 
-export interface QuizAB extends BaseQuiz {
-  type: 'ABTest';
-  options: [string, string];
+export interface BaseQuizAPI {
+  id: number; // 퀴즈 ID
+  content: string; // 퀴즈 내용
+  type: 'OX 퀴즈' | 'ABTest' | '객관식'; // 퀴즈 타입
+  author?: string; // 없다면 default
+  avatarUrl?: string; // 없다면 default
+  options: QuizOption[]; // 선택지
+  answer: QuizAnswer; // 정답 내용, 해설 담는 객체
+  count: QuizCount; // 좋아요와 댓글 수 담는 객체
+  liked?: boolean; // 사용자의 좋아요 여부 (검색페이지에서만 사용)
+  answeredOption?: number; // 사용자가 선택한 옵션 번호 (검색페이지에서만 사용)
 }
-
-export interface QuizMul extends BaseQuiz {
-  type: 'MultipleChoice';
-  options: string[];
-}
-
-export type Quiz = QuizOX | QuizAB | QuizMul;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './NavBarType';
 export * from './QuizTypes';
+export * from './CommentTypes';


### PR DESCRIPTION
## 작업 내용

- API 명세에 맞춰 Quiz와 Comment 타입 정의 및 수정
- QuizWrapper와 각 퀴즈 유형별 컴포넌트 내부 로직을 수정하여 새로운 데이터 구조 반영
- BottomSheet에서 댓글 데이터 렌더링 및 로딩 상태 처리 추가
- QuizWrapper 로직 분리