### PR TITLE
[FEAT]: 퀴즈 수정 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,14 @@ import MainLayout from './layouts/MainLayout';
 import AuthLayout from './layouts/AuthLayout';
 import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
 import { GamePage, MainPage, MyPage, SearchPage } from './pages';
-import { AbPage, OxPage, MultipleChoicePage } from './pages/quiz';
+import {
+  AbPage,
+  OxPage,
+  MultipleChoicePage,
+  EditOxQuizPage,
+  EditAbQuizPage,
+  EditMultipleQuizPage,
+} from './pages/quiz';
 import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play, Result } from './pages/game';
 import { useState } from 'react';
 import ReviewNote from './pages/profile/ReviewNote';
@@ -38,6 +45,9 @@ function App() {
           <Route path="/quiz/ab" element={<AbPage />} />
           <Route path="/quiz/ox" element={<OxPage />} />
           <Route path="/quiz/multiple" element={<MultipleChoicePage />} />
+          <Route path="/quiz/edit/ox/:id" element={<EditOxQuizPage />} />
+          <Route path="/quiz/edit/ab/:id" element={<EditAbQuizPage />} />
+          <Route path="/quiz/edit/multiple/:id" element={<EditMultipleQuizPage />} />
           {/* 추가적인 페이지 라우팅을 등록 */}
         </Route>
         <Route path="/game/play" element={<Play />} />

--- a/src/pages/quiz/AbPage.tsx
+++ b/src/pages/quiz/AbPage.tsx
@@ -10,6 +10,7 @@ import TopBar from '@/components/common/TopBar';
 import Card from '@/components/common/Card';
 import Container from '@/shared/Container';
 import Label from '@/shared/Label';
+import ToastMessage from '@/components/common/ToastMessage';
 
 export default function ABTestPage() {
   const navigate = useNavigate();
@@ -27,6 +28,9 @@ export default function ABTestPage() {
     optionB: false,
     explanation: false,
   });
+
+  const [toastOpen, setToastOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState({ message: '', icon: 'check' });
 
   useEffect(() => {
     if (location.pathname === '/quiz/ab') {
@@ -69,7 +73,7 @@ export default function ABTestPage() {
     }
   };
 
-  const handleSubmit = () => {
+  const validateFields = () => {
     const updatedErrors = {
       question: question.trim() === '',
       optionA: optionA.trim() === '',
@@ -79,14 +83,23 @@ export default function ABTestPage() {
 
     setFieldErrors(updatedErrors);
 
-    if (
-      !updatedErrors.question &&
-      !updatedErrors.optionA &&
-      !updatedErrors.optionB &&
-      !updatedErrors.explanation
-    ) {
-      console.log({ question, optionA, imageA, optionB, imageB, explanation });
+    // 에러가 있는 경우 false 반환
+    return !Object.values(updatedErrors).some((error) => error);
+  };
+
+  const handleSubmit = () => {
+    const isValid = validateFields();
+
+    if (!isValid) {
+      setToastMessage({ message: '필드를 모두 채워주세요.', icon: 'warning' });
+      setToastOpen(true);
+      return;
     }
+
+    setToastMessage({ message: '퀴즈가 생성되었습니다!', icon: 'check' });
+    setToastOpen(true);
+
+    console.log({ question, optionA, imageA, optionB, imageB, explanation });
   };
 
   return (
@@ -216,9 +229,16 @@ export default function ABTestPage() {
             state={fieldErrors.explanation ? 'error' : 'enable'}
           />
         </Card>
+
         <ShadcnButton className="w-full h-12 text-lg" size="default" onClick={handleSubmit}>
           퀴즈 생성하기
         </ShadcnButton>
+        <ToastMessage
+          message={toastMessage.message}
+          icon={toastMessage.icon as 'check' | 'warning'}
+          open={toastOpen}
+          setOpen={setToastOpen}
+        />
       </Container>
     </FlexBox>
   );

--- a/src/pages/quiz/EditAbQuizPage.tsx
+++ b/src/pages/quiz/EditAbQuizPage.tsx
@@ -1,0 +1,262 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+// import axios from 'axios'; // 서버와 연결 시 활성화
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TextField from '@eolluga/eolluga-ui/Input/TextField';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import Icon from '@eolluga/eolluga-ui/icon/Icon';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+// Mock 데이터
+const MOCK_DATA = {
+  type: 'AB',
+  content: 'AB 퀴즈 내용',
+  optionA: {
+    text: 'A 선택지 텍스트',
+    image: null,
+  },
+  optionB: {
+    text: 'B 선택지 텍스트',
+    image: null,
+  },
+  explanation: 'AB 퀴즈 해설',
+};
+
+export default function EditAbQuizPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [quizData, setQuizData] = useState({
+    content: '', // 문제
+    optionA: { text: '', image: null as File | null }, // A 선택지
+    optionB: { text: '', image: null as File | null }, // B 선택지
+    explanation: '', // 해설
+  });
+
+  const [fieldErrors, setFieldErrors] = useState({
+    content: false,
+    optionA: false,
+    optionB: false,
+    explanation: false,
+  });
+
+  useEffect(() => {
+    // Mock 데이터 퀴즈로 로드
+    console.log('Mock 데이터 로드:', MOCK_DATA);
+    setQuizData(MOCK_DATA);
+
+    // 서버 연결 시 활성화
+    // const fetchQuiz = async () => {
+    //   try {
+    //     const response = await axios.get(`/api/quiz/${id}`);
+    //     setQuizData(response.data.result);
+    //   } catch (error) {
+    //     console.error('퀴즈 데이터를 불러오는 중 오류 발생:', error);
+    //   }
+    // };
+    // fetchQuiz();
+  }, [id]);
+
+  const handleInputChange = (field: string, value: string) => {
+    setQuizData((prev) => ({ ...prev, [field]: value }));
+    setFieldErrors((prev) => ({ ...prev, [field]: false }));
+  };
+
+  const handleOptionChange = (
+    option: 'optionA' | 'optionB',
+    field: 'text' | 'image',
+    value: string | File | null,
+  ) => {
+    setQuizData((prev) => ({
+      ...prev,
+      [option]: {
+        ...prev[option],
+        [field]: value,
+      },
+    }));
+
+    if (field === 'text') {
+      setFieldErrors((prev) => ({ ...prev, [option]: value === '' }));
+    }
+  };
+
+  const validateFields = () => {
+    const errors = {
+      content: quizData.content.trim() === '',
+      optionA: quizData.optionA.text.trim() === '',
+      optionB: quizData.optionB.text.trim() === '',
+      explanation: quizData.explanation.trim() === '',
+    };
+    setFieldErrors(errors);
+    return !Object.values(errors).some((err) => err);
+  };
+
+  const handleSubmit = async () => {
+    if (!validateFields()) {
+      console.log('수정 에러 발생:', fieldErrors);
+      return;
+    }
+
+    console.log('AB 퀴즈 수정 데이터 제출:', quizData);
+
+    // 서버 연결 시 활성화
+    // try {
+    //   await axios.put(`/api/quiz/${id}`, quizData);
+    //   alert('퀴즈가 성공적으로 수정되었습니다.');
+    //   navigate('/profile/quizManagement');
+    // } catch (error) {
+    //   console.error('퀴즈 수정 중 오류 발생:', error);
+    //   alert('퀴즈 수정 중 오류가 발생했습니다.');
+    // }
+  };
+
+  const handleImageChange = (
+    option: 'optionA' | 'optionB',
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (e.target.files && e.target.files[0]) {
+      handleOptionChange(option, 'image', e.target.files[0]);
+    }
+  };
+
+  const removeImage = (option: 'optionA' | 'optionB') => {
+    handleOptionChange(option, 'image', null);
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="AB 테스트 수정" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="퀴즈 유형" htmlFor="quiz-type" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="OX 퀴즈"
+                checked={false}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="AB 테스트"
+                checked={true}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="객관식"
+                checked={false}
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <Label content="문제" />
+            <TextArea
+              value={quizData.content}
+              onChange={(e) => handleInputChange('content', e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.content ? 'error' : 'enable'}
+            />
+          </div>
+
+          <div className="mb-4">
+            <div className="mb-2">
+              <Label content="A 선택지" />
+              <TextField
+                mode="outlined"
+                value={quizData.optionA.text}
+                onChange={(e) => handleOptionChange('optionA', 'text', e.target.value)}
+                placeholder="A 선택지 텍스트를 입력하세요."
+                size="M"
+                state={fieldErrors.optionA ? 'error' : 'enable'}
+              />
+            </div>
+            <Label content="A 이미지 첨부" htmlFor="image-a" className="mb-1" />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleImageChange('optionA', e)}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            {quizData.optionA.image && (
+              <div className="relative mt-2">
+                <img
+                  src={URL.createObjectURL(quizData.optionA.image as File)}
+                  alt="A 선택지 이미지"
+                  className="w-full h-20 object-cover rounded border"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage('optionA')}
+                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                >
+                  <Icon icon="close" size={20} />
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="mb-4">
+            <div className="mb-2">
+              <Label content="B 선택지" />
+              <TextField
+                mode="outlined"
+                value={quizData.optionB.text}
+                onChange={(e) => handleOptionChange('optionB', 'text', e.target.value)}
+                placeholder="B 선택지 텍스트를 입력하세요."
+                size="M"
+                state={fieldErrors.optionB ? 'error' : 'enable'}
+              />
+            </div>
+            <Label content="B 이미지 첨부" htmlFor="image-b" className="mb-1" />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => handleImageChange('optionB', e)}
+              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+            />
+            {quizData.optionB.image && (
+              <div className="relative mt-2">
+                <img
+                  src={URL.createObjectURL(quizData.optionB.image as File)}
+                  alt="B 선택지 이미지"
+                  className="w-full h-20 object-cover rounded border"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeImage('optionB')}
+                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                >
+                  <Icon icon="close" size={20} />
+                </button>
+              </div>
+            )}
+          </div>
+
+          <Label content="해설" />
+          <TextArea
+            value={quizData.explanation}
+            onChange={(e) => handleInputChange('explanation', e.target.value)}
+            placeholder="해설을 입력하세요."
+            size="M"
+            state={fieldErrors.explanation ? 'error' : 'enable'}
+          />
+        </Card>
+        <ShadcnButton size="default" className="w-full h-12 text-lg" onClick={handleSubmit}>
+          퀴즈 수정하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/EditMultipleQuizPage.tsx
+++ b/src/pages/quiz/EditMultipleQuizPage.tsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+// import axios from 'axios'; // 서버 연결 시 다시 활성화
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import TextField from '@eolluga/eolluga-ui/Input/TextField';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+// Mock 데이터
+const MOCK_DATA = {
+  id: 2,
+  type: 'Multiple',
+  content: '객관식 문제 내용',
+  tags: ['일상', '태그', '테스트'],
+  options: [
+    { optionNumber: 1, title: 'react' },
+    { optionNumber: 2, title: 'notion' },
+    { optionNumber: 3, title: 'github' },
+    { optionNumber: 4, title: 'jira' },
+  ],
+  answer: 4,
+  explanation: '객관식 퀴즈 해설',
+};
+
+export default function EditMultipleChoicePage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [quizData, setQuizData] = useState({
+    content: '',
+    options: [] as { optionNumber: number; title: string }[],
+    answer: 0, // 정답 번호 (0 = 선택 안 됨)
+    explanation: '',
+  });
+
+  const [fieldErrors, setFieldErrors] = useState({
+    content: false,
+    options: [false, false, false, false],
+    answer: false,
+    explanation: false,
+  });
+
+  useEffect(() => {
+    // Mock 데이터 로드
+    console.log('Mock 데이터 로드:', MOCK_DATA);
+    setQuizData(MOCK_DATA);
+
+    // 서버 연결 시 활성화
+    // const fetchQuiz = async () => {
+    //   try {
+    //     const response = await axios.get(`/api/quiz/${id}`);
+    //     setQuizData(response.data.result);
+    //   } catch (error) {
+    //     console.error('퀴즈 데이터를 불러오는 중 오류 발생:', error);
+    //   }
+    // };
+    // fetchQuiz();
+  }, [id]);
+
+  const handleInputChange = (field: string, value: string | number) => {
+    setQuizData((prev) => ({ ...prev, [field]: value }));
+    if (field !== 'options') {
+      setFieldErrors((prev) => ({ ...prev, [field]: false }));
+    }
+  };
+
+  const handleOptionChange = (optionNumber: number, value: string) => {
+    const updatedOptions = quizData.options.map((option) =>
+      option.optionNumber === optionNumber ? { ...option, title: value } : option,
+    );
+    setQuizData((prev) => ({ ...prev, options: updatedOptions }));
+
+    const updatedErrors = [...fieldErrors.options];
+    updatedErrors[optionNumber - 1] = value.trim() === '';
+    setFieldErrors((prev) => ({ ...prev, options: updatedErrors }));
+  };
+
+  const handleAnswerChange = (optionNumber: number) => {
+    // 동일한 답변 클릭 시 선택 해제
+    setQuizData((prev) => ({
+      ...prev,
+      answer: prev.answer === optionNumber ? 0 : optionNumber,
+    }));
+    setFieldErrors((prev) => ({ ...prev, answer: false }));
+  };
+
+  const validateFields = () => {
+    const errors = {
+      content: quizData.content.trim() === '',
+      options: quizData.options.map((option) => option.title.trim() === ''),
+      answer: quizData.answer === 0, // 정답 번호가 없으면 error
+      explanation: quizData.explanation.trim() === '',
+    };
+
+    setFieldErrors(errors);
+    return (
+      !errors.content &&
+      !errors.explanation &&
+      !errors.answer &&
+      !errors.options.some((error) => error)
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!validateFields()) {
+      console.log('수정 에러 발생:', fieldErrors);
+      return;
+    }
+
+    console.log('객관식 수정 데이터 제출:', quizData);
+
+    // 서버 연결 시 활성화
+    // try {
+    //   await axios.put(`/api/quiz/${id}`, quizData);
+    //   alert('퀴즈가 성공적으로 수정되었습니다.');
+    //   navigate('/profile/quizManagement');
+    // } catch (error) {
+    //   console.error('퀴즈 수정 중 오류 발생:', error);
+    //   alert('퀴즈 수정 중 오류가 발생했습니다.');
+    // }
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="객관식 퀴즈 수정" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="문제" />
+            <TextArea
+              value={quizData.content}
+              onChange={(e) => handleInputChange('content', e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.content ? 'error' : 'enable'}
+            />
+          </div>
+
+          <div className="mb-4">
+            {quizData.options.map((option) => (
+              <div key={option.optionNumber} className="mb-2">
+                <Label content={`${option.optionNumber}번 선택지`} />
+                <TextField
+                  mode="outlined"
+                  value={option.title}
+                  onChange={(e) => handleOptionChange(option.optionNumber, e.target.value)}
+                  placeholder={`${option.optionNumber}번 선택지를 입력하세요.`}
+                  size="M"
+                  state={fieldErrors.options[option.optionNumber - 1] ? 'error' : 'enable'}
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="mb-4">
+            <Label content="정답" />
+            <div className="flex flex-row items-center gap-4">
+              {quizData.options.map((option) => (
+                <Radio
+                  key={option.optionNumber}
+                  size="M"
+                  state={fieldErrors.answer ? 'error' : 'enable'}
+                  title={`${option.optionNumber}`}
+                  checked={quizData.answer === option.optionNumber}
+                  onChange={() => handleAnswerChange(option.optionNumber)}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <Label content="해설" />
+            <TextArea
+              value={quizData.explanation}
+              onChange={(e) => handleInputChange('explanation', e.target.value)}
+              placeholder="해설을 입력하세요."
+              size="M"
+              state={fieldErrors.explanation ? 'error' : 'enable'}
+            />
+          </div>
+        </Card>
+        <ShadcnButton size="default" className="w-full h-12 text-lg" onClick={handleSubmit}>
+          퀴즈 수정하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/EditOxQuizPage.tsx
+++ b/src/pages/quiz/EditOxQuizPage.tsx
@@ -1,0 +1,174 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+// import axios from 'axios'; // 서버 연결 시 다시 활성화
+import { Button as ShadcnButton } from '@/shadcn/ui/button';
+import FlexBox from '@/shared/FlexBox';
+import Radio from '@eolluga/eolluga-ui/Input/Radio';
+import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
+import TopBar from '@/components/common/TopBar';
+import Card from '@/components/common/Card';
+import Container from '@/shared/Container';
+import Label from '@/shared/Label';
+
+// Mock 데이터
+const MOCK_DATA = {
+  type: 'OX',
+  content: 'OX 퀴즈 내용',
+  answer: 'O',
+  explanation: '정답',
+};
+
+export default function EditOxQuizPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [quizData, setQuizData] = useState({
+    content: '', // 질문
+    answer: '', // 정답
+    explanation: '', // 해설
+  });
+
+  const [fieldErrors, setFieldErrors] = useState({
+    content: false,
+    explanation: false,
+    answer: false,
+  });
+
+  useEffect(() => {
+    // Mock 데이터 로드
+    console.log('Mock 데이터 로드:', MOCK_DATA);
+    setQuizData(MOCK_DATA);
+
+    // 서버 연결 시 활성화
+    // const fetchQuiz = async () => {
+    //   try {
+    //     const response = await axios.get(`/api/quiz/${id}`);
+    //     setQuizData(response.data.result);
+    //   } catch (error) {
+    //     console.error('퀴즈 데이터를 불러오는 중 오류 발생:', error);
+    //   }
+    // };
+    // fetchQuiz();
+  }, [id]);
+
+  const handleInputChange = (field: string, value: string) => {
+    setQuizData((prev) => ({ ...prev, [field]: value }));
+    setFieldErrors((prev) => ({ ...prev, [field]: false })); // 입력 시 에러 제거
+  };
+
+  const handleAnswerChange = (answer: string) => {
+    // 동일한 답변 클릭 시 선택 해제
+    setQuizData((prev) => ({
+      ...prev,
+      answer: prev.answer === answer ? '' : answer,
+    }));
+    setFieldErrors((prev) => ({ ...prev, answer: false })); // 선택 시 에러 제거
+  };
+
+  const validateFields = () => {
+    const errors = {
+      content: quizData.content.trim() === '',
+      explanation: quizData.explanation.trim() === '',
+      answer: quizData.answer === '', // 정답이 비어 있으면 에러
+    };
+    setFieldErrors(errors);
+    return !Object.values(errors).some((err) => err);
+  };
+
+  const handleSubmit = async () => {
+    if (!validateFields()) {
+      console.log('수정 에러 발생:', fieldErrors);
+      return;
+    }
+
+    console.log('OX 퀴즈 수정 데이터 제출:', quizData);
+
+    // 서버 연결 시 활성화
+    // try {
+    //   await axios.put(`/api/quiz/${id}`, quizData);
+    //   alert('퀴즈가 성공적으로 수정되었습니다.');
+    //   navigate('/profile/quizManagement');
+    // } catch (error) {
+    //   console.error('퀴즈 수정 중 오류 발생:', error);
+    //   alert('퀴즈 수정 중 오류가 발생했습니다.');
+    // }
+  };
+
+  return (
+    <FlexBox direction="col">
+      <Container>
+        <TopBar leftIcon="left" leftText="OX 퀴즈 수정" onClickLeft={() => navigate(-1)} />
+        <Card>
+          <div className="mb-4">
+            <Label content="퀴즈 유형" htmlFor="quiz-type" className="mb-1" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="OX 퀴즈"
+                checked={true}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="AB 테스트"
+                checked={false}
+              />
+              <Radio
+                alert="퀴즈 유형을 선택해주세요."
+                size="M"
+                state="readOnly"
+                title="객관식"
+                checked={false}
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <Label content="문제" />
+            <TextArea
+              value={quizData.content}
+              onChange={(e) => handleInputChange('content', e.target.value)}
+              placeholder="문제를 입력하세요."
+              size="M"
+              state={fieldErrors.content ? 'error' : 'enable'}
+            />
+          </div>
+
+          <div className="mb-4">
+            <Label content="정답" />
+            <div className="flex flex-row items-center gap-4">
+              <Radio
+                size="M"
+                state={fieldErrors.answer ? 'error' : 'enable'}
+                title="O"
+                checked={quizData.answer === 'O'}
+                onChange={() => handleAnswerChange('O')}
+              />
+              <Radio
+                size="M"
+                state={fieldErrors.answer ? 'error' : 'enable'}
+                title="X"
+                checked={quizData.answer === 'X'}
+                onChange={() => handleAnswerChange('X')}
+              />
+            </div>
+          </div>
+
+          <Label content="해설" />
+          <TextArea
+            value={quizData.explanation}
+            onChange={(e) => handleInputChange('explanation', e.target.value)}
+            placeholder="해설을 입력하세요."
+            size="M"
+            state={fieldErrors.explanation ? 'error' : 'enable'}
+          />
+        </Card>
+        <ShadcnButton size="default" className="w-full h-12 text-lg" onClick={handleSubmit}>
+          퀴즈 수정하기
+        </ShadcnButton>
+      </Container>
+    </FlexBox>
+  );
+}

--- a/src/pages/quiz/OxPage.tsx
+++ b/src/pages/quiz/OxPage.tsx
@@ -4,7 +4,6 @@ import { Button as ShadcnButton } from '@/shadcn/ui/button';
 import FlexBox from '@/shared/FlexBox';
 import Radio from '@eolluga/eolluga-ui/Input/Radio';
 import TextArea from '@eolluga/eolluga-ui/Input/TextArea';
-import Icon from '@eolluga/eolluga-ui/icon/Icon';
 import TopBar from '@/components/common/TopBar';
 import Card from '@/components/common/Card';
 import Container from '@/shared/Container';

--- a/src/pages/quiz/OxPage.tsx
+++ b/src/pages/quiz/OxPage.tsx
@@ -19,7 +19,6 @@ export default function OXQuizPage() {
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [question, setQuestion] = useState('');
   const [explanation, setExplanation] = useState('');
-  const [image, setImage] = useState<File | null>(null);
 
   const [fieldErrors, setFieldErrors] = useState({
     question: false,
@@ -59,16 +58,6 @@ export default function OXQuizPage() {
     setFieldErrors((prev) => ({ ...prev, answer: false }));
   };
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      setImage(e.target.files[0]);
-    }
-  };
-
-  const removeImage = () => {
-    setImage(null);
-  };
-
   const validateFields = () => {
     const updatedErrors = {
       question: question.trim() === '',
@@ -98,7 +87,6 @@ export default function OXQuizPage() {
       question,
       selectedAnswer,
       explanation,
-      image,
     });
   };
 
@@ -147,32 +135,6 @@ export default function OXQuizPage() {
             />
           </div>
           <div className="mb-4">
-            <Label content="이미지 첨부 (최대 1개)" htmlFor="quiz-image" className="mb-1" />
-            <input
-              id="quiz-image"
-              type="file"
-              accept="image/*"
-              onChange={handleImageChange}
-              className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
-            />
-            {image && (
-              <div className="relative mt-2">
-                <img
-                  src={URL.createObjectURL(image)}
-                  alt="Uploaded"
-                  className="w-full h-full object-cover rounded border"
-                />
-                <button
-                  type="button"
-                  onClick={removeImage}
-                  className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs"
-                >
-                  <Icon icon="close" size={48} />
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="mb-4">
             <Label content="정답" htmlFor="answer" className="mb-1" />
             <div className="flex flex-row items-center gap-4">
               <Radio
@@ -204,12 +166,12 @@ export default function OXQuizPage() {
         <ShadcnButton className="w-full h-12 text-lg" size="default" onClick={handleSubmit}>
           퀴즈 생성하기
         </ShadcnButton>
-        {/* 토스트 크기 수정 필요 <ToastMessage
+        <ToastMessage
           message={toastMessage.message}
           icon={toastMessage.icon as 'check' | 'warning'}
           open={toastOpen}
           setOpen={setToastOpen}
-        /> */}
+        />
       </Container>
     </FlexBox>
   );

--- a/src/pages/quiz/index.ts
+++ b/src/pages/quiz/index.ts
@@ -1,3 +1,6 @@
 export { default as AbPage } from './AbPage';
 export { default as OxPage } from './OxPage';
 export { default as MultipleChoicePage } from './MultipleChoicePage';
+export { default as EditOxQuizPage } from './EditOxQuizPage';
+export { default as EditMultipleQuizPage } from './EditMultipleQuizPage';
+export { default as EditAbQuizPage } from './EditAbQuizPage';


### PR DESCRIPTION
- 각 퀴즈 수정 페이지 생성 (임시 Mock 데이터)
- radio 버튼 에러 발생시 화면 틀어짐 수정
- OX, 객관식 이미지 삽입 기능 삭제
- 각 퀴즈 생성 페이지에 ToastMessage 적용 ( toast 수정 필요할듯 합니다. 일단 넣어둠 )
- 내 퀴즈 관리는 아직 API 명세가 나오지 않아 보류했습니다.