### PR TITLE
[FEAT]: 관심사 api 연동 및 관심사 수정

### DIFF
--- a/src/api/login/useRegisterInterests.ts
+++ b/src/api/login/useRegisterInterests.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query';
+import axiosInstance from '@/api/axiosInstance';
+
+interface RegisterInterestsRequest {
+  interests: string[];
+}
+
+async function registerInterests(requestData: RegisterInterestsRequest): Promise<void> {
+  //TODO: 관심사 등록 요청
+  console.log('관심사 등록 요청:', requestData.interests);
+  await axiosInstance.post('/quiz/users/interests', requestData.interests, {});
+}
+
+function useRegisterInterests(onSuccess?: () => void, onError?: (error: any) => void) {
+  return useMutation({
+    mutationKey: ['registerInterests'],
+    mutationFn: registerInterests,
+    onSuccess: () => {
+      console.log('관심사가 성공적으로 등록되었습니다.');
+      if (onSuccess) onSuccess();
+    },
+    onError: (error) => {
+      console.error('관심사 등록 실패:', error);
+      if (onError) onError(error);
+    },
+  });
+}
+
+export default useRegisterInterests;

--- a/src/pages/Login/InterestPage.tsx
+++ b/src/pages/Login/InterestPage.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button as ShadcnButton } from '@/shadcn/ui/button';
 import InterestButton from '../../components/common/Button/InterestButton';
+import useRegisterInterests from '@/api/login/useRegisterInterests';
+import { toEnglishCategory } from '@/utils/categoryConverter';
 
-const mock_interests = [
+const interests = [
   '알고리즘',
   '프로그래밍 언어',
   '네트워크',
@@ -15,6 +18,7 @@ const mock_interests = [
 ];
 
 function InterestPage() {
+  const navigate = useNavigate();
   const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
 
   const handleInterestSelect = (interest: string) => {
@@ -23,6 +27,21 @@ function InterestPage() {
         ? prevSelected.filter((item) => item !== interest)
         : [...prevSelected, interest],
     );
+  };
+
+  const { mutate: registerInterests } = useRegisterInterests(
+    () => {
+      console.log('관심사가 성공적으로 등록되었습니다.');
+    },
+    (error) => {
+      console.error(error);
+    },
+  );
+
+  const handleSubmit = () => {
+    const englishInterests = selectedInterests.map(toEnglishCategory);
+    registerInterests({ interests: englishInterests });
+    navigate('/main');
   };
 
   return (
@@ -34,7 +53,7 @@ function InterestPage() {
         </p>
 
         <div className="grid grid-cols-2 gap-4 mb-8">
-          {mock_interests.map((interest) => (
+          {interests.map((interest) => (
             <InterestButton
               key={interest}
               label={interest}
@@ -50,7 +69,8 @@ function InterestPage() {
           variant="default"
           size="lg"
           className="w-full h-12 text-base"
-          onClick={() => console.log('선택된 관심사:', selectedInterests)}
+          onClick={handleSubmit}
+          disabled={selectedInterests.length === 0} // 로딩 중 또는 선택된 관심사가 없을 때 버튼 비활성화
         >
           선택 완료
         </ShadcnButton>

--- a/src/utils/categoryConverter.ts
+++ b/src/utils/categoryConverter.ts
@@ -5,7 +5,7 @@ const categoryMap: Record<string, string> = {
   운영체제: 'OPERATING_SYSTEM',
   '웹 개발': 'WEB_DEVELOPMENT',
   '모바일 개발': 'MOBILE',
-  '데브옵스/인프라': 'DEVOPS_INFRASTRUCTURE',
+  '데브옵스/인프라': 'DEV_OPS',
   데이터베이스: 'DATABASE',
   '소프트웨어 공학': 'SOFTWARE_ENGINEERING',
 };
@@ -13,4 +13,12 @@ const categoryMap: Record<string, string> = {
 // 한글 카테고리를 영어로 변환
 export const toEnglishCategory = (koreanCategory: string): string => {
   return categoryMap[koreanCategory] || '';
+};
+
+// 영어 카테고리를 한글로 변환
+export const toKoreanCategory = (englishCategory: string): string => {
+  const reversedMap = Object.fromEntries(
+    Object.entries(categoryMap).map(([korean, english]) => [english, korean]),
+  );
+  return reversedMap[englishCategory] || '';
 };


### PR DESCRIPTION
- 관심사 API 연동 추가
   - 수정 API 보류
   - 최초 로그인 시에만 접근 가능 조건 추가 필요

- 제 카카오톡 USER 정보가 재 배포시 누락됐는지 퀴즈 CRUD는 정상적으로 작동하는데, 관심사만 안되는 이슈가 있었습니다. 다른분들도 확인 부탁드립니다. `ex) 404 (Not Found)`