### PR TITLE
[Feat]: 댓글 컴포넌트 기능 및 연동

### DIFF
--- a/src/api/comments/addComments.ts
+++ b/src/api/comments/addComments.ts
@@ -2,25 +2,21 @@ import { useMutation } from '@tanstack/react-query';
 import axiosInstance from '../axiosInstance';
 
 interface AddCommentVariables {
-  writerId: number;
   parentCommentId: number;
   content: string;
 }
 
 const addCommentAPI = async ({
   quizId,
-  writerId,
   parentCommentId,
   content,
 }: {
   quizId: number;
-  writerId: number;
   parentCommentId: number;
   content: string;
 }): Promise<void> => {
   const response = await axiosInstance.post('/quiz/comments', {
     quizId,
-    writerId,
     parentCommentId,
     content,
   });

--- a/src/api/comments/addComments.ts
+++ b/src/api/comments/addComments.ts
@@ -23,20 +23,16 @@ const addCommentAPI = async ({
   console.log('댓글 등록 응답:', response.data);
 };
 
-function useAddComment(quizId: number) {
-  //   const queryClient = useQueryClient();
-
+const useAddComment = (quizId: number) => {
   return useMutation({
-    mutationKey: ['addComment', quizId],
     mutationFn: (newComment: AddCommentVariables) => addCommentAPI({ quizId, ...newComment }),
     onSuccess: () => {
       console.log('댓글 등록 성공');
-      //   queryClient.invalidateQueries(['comments', quizId]);
     },
     onError: (error: Error) => {
       console.error('댓글 등록 실패:', error.message);
     },
   });
-}
+};
 
 export default useAddComment;

--- a/src/api/comments/deleteComments.ts
+++ b/src/api/comments/deleteComments.ts
@@ -1,28 +1,43 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axiosInstance from '../axiosInstance';
+import { Comment } from '@/types';
 
 const deleteCommentAPI = async (commentId: number): Promise<void> => {
-  try {
-    const response = await axiosInstance.delete(`/quiz/comments/${commentId}`);
-    console.log('댓글 삭제 응답 성공:', response.data);
-  } catch (error) {
-    console.error('댓글 삭제 API 호출 실패:', error);
-    throw error;
-  }
+  const response = await axiosInstance.delete(`/quiz/comments/${commentId}`);
+  console.log('댓글 삭제 응답 성공:', response.data);
 };
 
 const useDeleteComment = (quizId: number) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationKey: ['deleteComment', quizId],
-    mutationFn: (commentId: number) => {
-      return deleteCommentAPI(commentId);
+    mutationFn: (commentId: number) => deleteCommentAPI(commentId),
+    onMutate: async (commentId) => {
+      // 이전 상태 저장
+      const previousComments = queryClient.getQueryData<Comment[]>(['comments', quizId]);
+
+      // 낙관적 업데이트
+      queryClient.setQueryData<Comment[]>(['comments', quizId], (old = []) =>
+        old.filter((comment) => comment.id !== commentId),
+      );
+
+      return { previousComments };
+    },
+    onError: (err, _commentId, context) => {
+      // 오류 발생 시 이전 상태 복원
+      if (context?.previousComments) {
+        queryClient.setQueryData(['comments', quizId], context.previousComments);
+      }
+      console.error('댓글 삭제 실패:', err);
+    },
+    onSettled: () => {
+      // 삭제 후 캐시 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['comments', quizId],
+      });
     },
     onSuccess: () => {
       console.log('댓글 삭제 성공');
-      //   queryClient.invalidateQueries(['comments', quizId]);
-    },
-    onError: (error: Error) => {
-      console.error('댓글 삭제 실패:', error.message);
     },
   });
 };

--- a/src/api/comments/deleteComments.ts
+++ b/src/api/comments/deleteComments.ts
@@ -2,16 +2,21 @@ import { useMutation } from '@tanstack/react-query';
 import axiosInstance from '../axiosInstance';
 
 const deleteCommentAPI = async (commentId: number): Promise<void> => {
-  const response = await axiosInstance.delete(`/quiz/comments/${commentId}`);
-  console.log('댓글 삭제 응답:', response.data);
+  try {
+    const response = await axiosInstance.delete(`/quiz/comments/${commentId}`);
+    console.log('댓글 삭제 응답 성공:', response.data);
+  } catch (error) {
+    console.error('댓글 삭제 API 호출 실패:', error);
+    throw error;
+  }
 };
 
 const useDeleteComment = (quizId: number) => {
-  //   const queryClient = useQueryClient();
-
   return useMutation({
     mutationKey: ['deleteComment', quizId],
-    mutationFn: (commentId: number) => deleteCommentAPI(commentId),
+    mutationFn: (commentId: number) => {
+      return deleteCommentAPI(commentId);
+    },
     onSuccess: () => {
       console.log('댓글 삭제 성공');
       //   queryClient.invalidateQueries(['comments', quizId]);

--- a/src/api/main/fetchQuiz.ts
+++ b/src/api/main/fetchQuiz.ts
@@ -1,0 +1,63 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import axiosInstance from '../axiosInstance';
+import { BaseQuizAPI } from '@/types';
+
+interface FetchQuizzesParams {
+  page: number;
+  size: number;
+  category?: string;
+}
+
+interface FetchQuizzesResponse {
+  quizzes: BaseQuizAPI[];
+  hasNext: boolean;
+  page: number;
+  category?: string;
+}
+
+const fetchQuizzes = async ({
+  page,
+  size,
+  category,
+}: FetchQuizzesParams): Promise<FetchQuizzesResponse> => {
+  try {
+    const params: Record<string, any> = { page, size };
+    if (category) params.category = category;
+
+    console.log('요청 URL:', '/quiz/my/feed');
+    console.log('요청 매개변수:', params);
+
+    const response = await axiosInstance.get('/quiz/my/feed', { params });
+    console.log('API 응답 데이터:', response.data);
+
+    const { slice, category: responseCategory } = response.data.result;
+
+    return {
+      quizzes: slice.quizzes,
+      hasNext: slice.hasNext,
+      page,
+      category: responseCategory,
+    };
+  } catch (error) {
+    console.error('API 호출 중 오류 발생:', error);
+    throw error;
+  }
+};
+
+const useQuizFeed = () => {
+  let category: string | undefined;
+
+  return useInfiniteQuery({
+    queryKey: ['quizFeed'],
+    queryFn: async ({ pageParam = 0 }) => {
+      const response = await fetchQuizzes({ page: pageParam, size: 5, category });
+      if (response.category) category = response.category;
+      return response;
+    },
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
+    initialPageParam: 0,
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export default useQuizFeed;

--- a/src/api/quiz/postAnswer.ts
+++ b/src/api/quiz/postAnswer.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query';
+import axiosInstance from '@/api/axiosInstance';
+
+const submitAnswerAPI = async (quizId: number, choiceNumber: number): Promise<void> => {
+  const requestData = { quizId, choiceNumber };
+  const response = await axiosInstance.post('/quiz/user-answers', requestData);
+  console.log('API 응답:', response.data);
+};
+
+export const usePostAnswer = () =>
+  useMutation<void, Error, { quizId: number; choiceNumber: number }>({
+    mutationFn: ({ quizId, choiceNumber }) => submitAnswerAPI(quizId, choiceNumber),
+  });

--- a/src/api/updateLike.ts
+++ b/src/api/updateLike.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import axiosInstance from '@/api/axiosInstance';
+
+const toggleLikeAPI = (quizId: number) => {
+  const requestData = { quizId };
+  return axiosInstance.post('/quiz/likes', requestData).then((res) => {
+    return res.data;
+  });
+};
+
+export const useToggleLike = (
+  onSuccessCallback?: () => void,
+  onErrorCallback?: (error: Error) => void,
+) => {
+  return useMutation<void, Error, number>({
+    mutationFn: toggleLikeAPI,
+    onSuccess: () => {
+      if (onSuccessCallback) onSuccessCallback();
+    },
+    onError: (error) => {
+      console.error('좋아요 요청 실패:', error);
+      if (onErrorCallback) onErrorCallback(error);
+    },
+  });
+};

--- a/src/components/comments/CommentInput.tsx
+++ b/src/components/comments/CommentInput.tsx
@@ -1,18 +1,27 @@
 import TextField from '@eolluga/eolluga-ui/Input/TextField';
 import Icon from '@eolluga/eolluga-ui/icon/Icon';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 interface CommentInputProps {
   onSubmit: (value: string) => void;
+  placeholder?: string;
 }
 
-export default function CommentInput({ onSubmit }: CommentInputProps) {
-  const [inputValue, setInputValue] = useState('');
+export default function CommentInput({
+  onSubmit,
+  placeholder = '댓글을 입력하세요...',
+}: CommentInputProps) {
+  const [value, setValue] = useState('');
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+    console.log('호출됨');
+  };
 
   const handleSubmit = () => {
-    if (inputValue.trim()) {
-      onSubmit(inputValue);
-      setInputValue('');
+    if (value.trim()) {
+      onSubmit(value.trim());
+      setValue('');
     }
   };
 
@@ -21,11 +30,12 @@ export default function CommentInput({ onSubmit }: CommentInputProps) {
       <div className="flex px-4 py-4 gap-4">
         <div className="flex items-center w-full bg-white border border-gray-100 rounded-lg overflow-hidden gap-1">
           <TextField
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
             size="M"
             mode="outlined"
-            placeholder="댓글을 입력하세요"
+            inputMode="text"
           />
           <div className="p-3 bg-black rounded-xl cursor-pointer" onClick={handleSubmit}>
             <Icon icon="add" className="fill-white" />

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -8,15 +8,26 @@ interface CommentItemProps {
   onDelete: (commentId: number) => void;
   toggleReplies?: () => void;
   expanded?: boolean;
+  onReply?: (parentCommentId: number) => void;
 }
 
-const CommentItem = ({ comment, onDelete, toggleReplies, expanded }: CommentItemProps) => (
+const CommentItem = ({ comment, onDelete, toggleReplies, expanded, onReply }: CommentItemProps) => (
   <div className="flex items-start gap-3 mb-2">
     <Avatar size="S" />
     <div className="flex-1">
       <div className="text-sm flex justify-between items-center">
         <span className="font-medium">User {comment.writerId}</span>
-        <div>
+        <div className="flex items-center gap-2">
+          {comment.parentCommentId === 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-blue-500 hover:underline"
+              onClick={() => onReply?.(comment.id)}
+            >
+              답글 달기
+            </Button>
+          )}
           <button
             onClick={() => onDelete(comment.id)}
             className="flex items-center justify-center pb-1 rounded bg-transparent hover:bg-gray-100 focus:bg-gray-200 active:bg-gray-300"

--- a/src/components/comments/CommentList.tsx
+++ b/src/components/comments/CommentList.tsx
@@ -6,30 +6,45 @@ interface CommentListProps {
   onDelete: (commentId: number) => void;
   expandedComments: { [key: number]: boolean };
   toggleReplies: (commentId: number) => void;
+  onReply: (parentCommentId: number) => void;
 }
 
-const CommentList = ({ comments, onDelete, expandedComments, toggleReplies }: CommentListProps) => (
-  <div className="p-4">
-    {comments.map((comment) => (
-      <div key={comment.id} className="mb-4 flex flex-col gap-2">
-        <div className="border-b pb-2">
-          <CommentItem
-            comment={comment}
-            onDelete={onDelete}
-            toggleReplies={() => toggleReplies(comment.id)}
-            expanded={!!expandedComments[comment.id]}
-          />
-        </div>
-        {expandedComments[comment.id] && comment.childComments && (
-          <div className="ml-6 border-l-2 pl-2">
-            {comment.childComments.map((childComment) => (
-              <CommentItem key={childComment.id} comment={childComment} onDelete={onDelete} />
-            ))}
+const CommentList = ({
+  comments,
+  onDelete,
+  expandedComments,
+  toggleReplies,
+  onReply,
+}: CommentListProps) => {
+  return (
+    <div className="p-4">
+      {comments.map((comment) => (
+        <div key={comment.id} className="mb-4 flex flex-col gap-2">
+          <div className="border-b pb-2">
+            <CommentItem
+              comment={comment}
+              onDelete={onDelete}
+              toggleReplies={() => toggleReplies(comment.id)}
+              expanded={!!expandedComments[comment.id]}
+              onReply={onReply}
+            />
           </div>
-        )}
-      </div>
-    ))}
-  </div>
-);
+          {expandedComments[comment.id] && comment.childComments && (
+            <div className="ml-6 border-l-2 pl-2">
+              {comment.childComments.map((childComment) => (
+                <CommentItem
+                  key={childComment.id}
+                  comment={childComment}
+                  onDelete={onDelete}
+                  onReply={onReply}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
 
 export default CommentList;

--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -7,9 +7,15 @@ interface CommentSectionProps {
   comments: Comment[];
   loading?: boolean;
   onDelete: (commentId: number) => void;
+  onReply: (parentCommentId: number) => void;
 }
 
-export default function CommentSection({ comments, loading, onDelete }: CommentSectionProps) {
+export default function CommentSection({
+  comments,
+  loading,
+  onDelete,
+  onReply,
+}: CommentSectionProps) {
   const [expandedComments, setExpandedComments] = useState<{ [key: number]: boolean }>({});
 
   const toggleReplies = (commentId: number) => {
@@ -38,6 +44,7 @@ export default function CommentSection({ comments, loading, onDelete }: CommentS
         onDelete={onDelete}
         expandedComments={expandedComments}
         toggleReplies={toggleReplies}
+        onReply={onReply}
       />
     </div>
   );

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/shadcn/ui/drawer';
 import Icon from '@eolluga/eolluga-ui/icon/Icon';
 import CommentSection from '../comments/CommentSection';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import CommentInput from '../comments/CommentInput';
 import useFetchComments from '@/api/comments/fetchComments';
 import useAddComment from '@/api/comments/addComments';
@@ -34,7 +34,14 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
   }, [isOpen, fetchComments]);
 
   const handleAddComment = (content: string, parentCommentId: number) => {
-    addCommentMutation.mutate({ content, parentCommentId });
+    addCommentMutation.mutate(
+      { parentCommentId, content },
+      {
+        onSuccess: () => {
+          fetchComments();
+        },
+      },
+    );
   };
 
   const handleDeleteComment = (commentId: number) => {

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -34,12 +34,11 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
   }, [isOpen, fetchComments]);
 
   const handleAddComment = (content: string, parentCommentId: number) => {
-    const writerId = 1;
-    addCommentMutation.mutate({ writerId, parentCommentId, content });
+    addCommentMutation.mutate({ content, parentCommentId });
   };
 
   const handleDeleteComment = (commentId: number) => {
-    deleteCommentMutation.mutate(commentId); // 댓글 삭제
+    deleteCommentMutation.mutate(commentId);
   };
 
   return (

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -23,6 +23,8 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
   const { comments, loading, fetchComments } = useFetchComments(quizId);
   const addCommentMutation = useAddComment(quizId);
   const deleteCommentMutation = useDeleteComment(quizId);
+  const [inputPlaceholder, setInputPlaceholder] = useState('댓글을 입력하세요...');
+  const [parentCommentId, setParentCommentId] = useState<number>(0);
 
   useEffect(() => {
     if (isOpen) {
@@ -33,11 +35,13 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
     }
   }, [isOpen, fetchComments]);
 
-  const handleAddComment = (content: string, parentCommentId: number) => {
+  const handleAddComment = (content: string) => {
     addCommentMutation.mutate(
       { parentCommentId, content },
       {
         onSuccess: () => {
+          setParentCommentId(0);
+          setInputPlaceholder('댓글을 입력하세요...');
           fetchComments();
         },
       },
@@ -46,6 +50,12 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
 
   const handleDeleteComment = (commentId: number) => {
     deleteCommentMutation.mutate(commentId);
+  };
+
+  const handleReply = (replyParentId: number) => {
+    setParentCommentId(replyParentId);
+    setInputPlaceholder('답글을 입력하세요...');
+    console.log(replyParentId);
   };
 
   return (
@@ -67,8 +77,13 @@ export default function BottomSheet({ isOpen, setOpen, quizId }: BottomSheetProp
             </button>
           </div>
         </DrawerHeader>
-        <CommentInput onSubmit={(content) => handleAddComment(content, 0)} />
-        <CommentSection comments={comments} loading={loading} onDelete={handleDeleteComment} />
+        <CommentInput onSubmit={handleAddComment} placeholder={inputPlaceholder} />
+        <CommentSection
+          comments={comments}
+          loading={loading}
+          onDelete={handleDeleteComment}
+          onReply={handleReply}
+        />
       </DrawerContent>
     </Drawer>
   );

--- a/src/components/quizComponent/QuizAns.tsx
+++ b/src/components/quizComponent/QuizAns.tsx
@@ -20,11 +20,11 @@ function QuizAns({ isCorrect, explanation, answerRate }: QuizAnsProps) {
             />
             {isCorrect ? '정답입니다!' : '틀렸습니다 ㅠㅠ'}
           </h4>
-          <span className="text-sm font-semibold text-gray-600">{answerRate.toFixed(1)}%</span>
+          <span className="text-sm font-semibold text-gray-600">
+            전체 정답률: {answerRate.toFixed(1)}%
+          </span>
         </div>
-        <p className={`mt-2 ${isCorrect ? 'text-green-500' : 'text-red-500'}`}>
-          전체 정답률: {explanation}
-        </p>
+        <p className={`mt-2 ${isCorrect ? 'text-green-500' : 'text-red-500'}`}>{explanation}</p>
       </div>
     </>
   );

--- a/src/components/quizComponent/QuizAns.tsx
+++ b/src/components/quizComponent/QuizAns.tsx
@@ -1,5 +1,4 @@
 import Icon from '@eolluga/eolluga-ui/icon/Icon';
-import ProgressBar from '../common/ProgressBar';
 
 interface QuizAnsProps {
   isCorrect: boolean;
@@ -11,23 +10,21 @@ function QuizAns({ isCorrect, explanation, answerRate }: QuizAnsProps) {
   return (
     <>
       <div className={`mt-1 p-2 rounded-lg ${isCorrect ? 'bg-green-100' : 'bg-red-100'}`}>
-        <h4
-          className={`flex items-center gap-2 font-bold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}
-        >
-          <Icon
-            icon={isCorrect ? 'chevron_down_circle' : 'close_circle'}
-            className={isCorrect ? 'text-green-600' : 'text-red-600'}
-          />
-          {isCorrect ? '정답입니다!' : '틀렸습니다 ㅠㅠ'}
-        </h4>
-        <p className={`mt-2 ${isCorrect ? 'text-green-500' : 'text-red-500'}`}>{explanation}</p>
-      </div>
-      <div className="mt-2">
-        <p className="mb-1 text-sm font-medium text-gray-700">전체 정답률</p>
-        <div className="flex items-center gap-2">
-          <ProgressBar progress={answerRate} colorClass="bg-pastelGreen" />
-          <span className="text-sm font-semibold text-gray-600">{answerRate.toFixed(1)}</span>
+        <div className="flex items-center justify-between">
+          <h4
+            className={`flex items-center gap-2 font-bold ${isCorrect ? 'text-green-600' : 'text-red-600'}`}
+          >
+            <Icon
+              icon={isCorrect ? 'chevron_down_circle' : 'close_circle'}
+              className={isCorrect ? 'text-green-600' : 'text-red-600'}
+            />
+            {isCorrect ? '정답입니다!' : '틀렸습니다 ㅠㅠ'}
+          </h4>
+          <span className="text-sm font-semibold text-gray-600">{answerRate.toFixed(1)}%</span>
         </div>
+        <p className={`mt-2 ${isCorrect ? 'text-green-500' : 'text-red-500'}`}>
+          전체 정답률: {explanation}
+        </p>
       </div>
     </>
   );

--- a/src/components/quizComponent/QuizWrapper.tsx
+++ b/src/components/quizComponent/QuizWrapper.tsx
@@ -3,6 +3,9 @@ import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useEffect, useState } from 'react';
 import { QuizAns, QuizFooter, QuizRenderer } from '.';
 import BottomSheet from '../common/BottomSheet';
+import axiosInstance from '@/api/axiosInstance';
+import { useMutation } from '@tanstack/react-query';
+import { useToggleLike } from '@/api/updateLike';
 
 interface QuizWrapperProps {
   quiz: BaseQuizAPI;
@@ -10,7 +13,7 @@ interface QuizWrapperProps {
 
 function QuizWrapper({ quiz }: QuizWrapperProps) {
   const [isLiked, setIsLiked] = useState(quiz.liked || false);
-  const [likes] = useState(quiz.count.like);
+  const [likes, setLikes] = useState(quiz.count.like);
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(quiz.answeredOption ?? null);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
@@ -42,6 +45,21 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
 
   const authorName = quiz.author?.name || 'default';
   const authorImage = quiz.author?.imagePath || '/';
+
+  const toggleLikeMutation = useToggleLike(
+    () => {
+      setIsLiked((prev) => !prev);
+      setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
+    },
+    (error) => {
+      console.error('좋아요 요청 중 오류 발생:', error);
+    },
+  );
+
+  const handleToggleLike = () => {
+    console.log(quiz.id);
+    toggleLikeMutation.mutate(quiz.id);
+  };
 
   return (
     <div className="flex justify-center">
@@ -75,7 +93,7 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
           likes={likes}
           comments={quiz.count.comment}
           isLiked={isLiked}
-          onToggleLike={() => setIsLiked(!isLiked)}
+          onToggleLike={handleToggleLike}
           onCommentsClick={() => setBottomSheetOpen(true)}
         />
       </div>

--- a/src/components/quizComponent/QuizWrapper.tsx
+++ b/src/components/quizComponent/QuizWrapper.tsx
@@ -3,9 +3,8 @@ import Avatar from '@eolluga/eolluga-ui/Display/Avatar';
 import { useEffect, useState } from 'react';
 import { QuizAns, QuizFooter, QuizRenderer } from '.';
 import BottomSheet from '../common/BottomSheet';
-import axiosInstance from '@/api/axiosInstance';
-import { useMutation } from '@tanstack/react-query';
 import { useToggleLike } from '@/api/updateLike';
+import { usePostAnswer } from '@/api/quiz/postAnswer';
 
 interface QuizWrapperProps {
   quiz: BaseQuizAPI;
@@ -19,6 +18,8 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
   const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
   const [isAnswerVisible, setIsAnswerVisible] = useState(false);
 
+  const submitAnswerMutation = usePostAnswer();
+
   useEffect(() => {
     if (selectedAnswer !== null) {
       setIsCorrect(selectedAnswer === quiz.answer?.answerNumber);
@@ -30,6 +31,9 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
   }, [selectedAnswer]);
 
   const handleAnswerSelect = (answer: number) => {
+    setSelectedAnswer(answer);
+    submitAnswerMutation.mutate({ quizId: quiz.id, choiceNumber: answer });
+
     if (selectedAnswer !== null) return;
     setSelectedAnswer(answer);
     if (quiz.answer) {
@@ -57,7 +61,6 @@ function QuizWrapper({ quiz }: QuizWrapperProps) {
   );
 
   const handleToggleLike = () => {
-    console.log(quiz.id);
     toggleLikeMutation.mutate(quiz.id);
   };
 

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -3,22 +3,35 @@ import 'swiper/css';
 import 'swiper/css/pagination';
 
 import TopBar from '@/components/common/TopBar';
-import { dummyQuizzes } from '@/data/dummyQuiz';
 import Container from '@/components/layout/Container';
 import QuizCard from './QuizCard';
+import useQuizFeed from '@/api/main/fetchQuiz';
 
 const MainPage = () => {
+  const { data, fetchNextPage, hasNextPage, isFetching, isError } = useQuizFeed();
+
+  const quizzes = data?.pages.flatMap((page) => page.quizzes) || [];
+
   return (
     <>
       <TopBar />
       <Container>
-        <Swiper direction="vertical" className="quizSwiper h-[80dvh]" spaceBetween={40}>
-          {dummyQuizzes.map((quiz) => (
+        <Swiper
+          direction="vertical"
+          className="quizSwiper h-[80dvh]"
+          spaceBetween={40}
+          onReachEnd={() => {
+            if (hasNextPage) fetchNextPage();
+          }}
+        >
+          {quizzes.map((quiz) => (
             <SwiperSlide key={quiz.id}>
               <QuizCard quiz={quiz} />
             </SwiperSlide>
           ))}
         </Swiper>
+        {isFetching && <div>로딩 중..</div>}
+        {isError && <div>데이터 불러오는 중..</div>}
       </Container>
     </>
   );


### PR DESCRIPTION
## 작업 내용

- 메인페이지 API 연동
- 퀴즈Ans 정답률 UI 수정
- 댓글 삭제 API 연동
- 댓글 등록 파라미터 변경
- 댓글 등록/삭제 시 화면 바로 반영
댓글 삭제 시에는 낙관적 업데이트 방식으로 리액트 쿼리 적용하였고,
댓글 등록은 WriterID를 서버에서 토큰으로 조회하기 때문에 낙관적 업데이트 방식 대신 댓글 등록 완료 후 댓글을 다시 조회해 띄워주는 방식으로 구현했습니다.
- 대댓글 등록 기능
TextField의 자판 노출을 트리거하는 부분을 건드릴 방법이 없어, 현재 '답글달기' 클릭 시 SearchInput이 '답글달기' 상태로 전환되고 자판은 올라오지 않는 이슈가 있습니다.
추후에 유튜브 쇼츠의 댓글 방식으로(답글 클릭 시 바텀시트가 부모댓글 위주로 재구성되도록) 수정할 예정입니다.

+
- 퀴즈 좋아요 API 연동
- 퀴즈 사용자 상호작용 API 연동

---

![comment](https://github.com/user-attachments/assets/545822e5-d573-4add-b239-20f61efae9f9)
