### PR TITLE
[FEAT] MyPage 오답노트 삭제기능 추가 및 UI개선

### DIFF
--- a/src/api/mypage/useReviewData.ts
+++ b/src/api/mypage/useReviewData.ts
@@ -1,0 +1,17 @@
+import axiosInstance from '@/api/axiosInstance';
+import { QuizWithAnswer } from '@/types/WrongQuizTypes';
+
+export const fetchIncorrectAnswers = async () => {
+  const response = await axiosInstance.get<{ result: { content: QuizWithAnswer[] } }>(
+    '/quiz/user-answers/incorrect',
+  );
+  return response.data.result.content;
+};
+
+export const updateQuizReviewStatus = async (quizId: number) => {
+  const response = await axiosInstance.patch('/quiz/user-answers', {
+    quizId: quizId,
+    reviewStatus: 'UNDERSTOOD',
+  });
+  return response.data;
+};

--- a/src/api/mypage/useUserData.ts
+++ b/src/api/mypage/useUserData.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
-import { Achievement } from '@/pages/MyPage';
+import { Achievement } from '@/pages/profile/MyPage';
 
 export interface UserData {
   id: number;

--- a/src/components/mypage/ReviewNoteCard.tsx
+++ b/src/components/mypage/ReviewNoteCard.tsx
@@ -2,11 +2,13 @@ import Icon from '@eolluga/eolluga-ui/icon/Icon';
 import { QuizWithAnswer } from '@/types/WrongQuizTypes';
 import Card from '@/components/common/Card';
 
-interface ReviewNoteCardProps {
+export default function ReviewNoteCard({
+  quizData,
+  onUpdate,
+}: {
   quizData: QuizWithAnswer;
-}
-
-export default function ReviewNoteCard({ quizData }: ReviewNoteCardProps) {
+  onUpdate: (quizId: number) => void;
+}) {
   const { quiz, userAnswer } = quizData;
   const formattedDate = new Date(userAnswer.answeredAt)
     .toLocaleDateString('ko-KR', {
@@ -16,9 +18,16 @@ export default function ReviewNoteCard({ quizData }: ReviewNoteCardProps) {
     })
     .replace(/\. /g, '.');
 
+  const handleUpdate = () => {
+    onUpdate(quizData.quiz.id);
+  };
+
   return (
     <Card className="relative">
-      <button className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center text-gray-400 rounded-full">
+      <button
+        onClick={handleUpdate}
+        className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center text-gray-400 rounded-full"
+      >
         <Icon icon="close" size={24} />
       </button>
 

--- a/src/hooks/useReviewNote.ts
+++ b/src/hooks/useReviewNote.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { QuizWithAnswer } from '@/types/WrongQuizTypes';
+import { fetchIncorrectAnswers, updateQuizReviewStatus } from '@/api/mypage/useReviewData';
+
+export const useReviewNote = () => {
+  const queryClient = useQueryClient();
+
+  const {
+    data: incorrectQuizzes = [],
+    isPending,
+    isError,
+    error,
+  } = useQuery<QuizWithAnswer[], Error>({
+    queryKey: ['incorrectQuizzes'],
+    queryFn: fetchIncorrectAnswers,
+  });
+
+  const updateQuizReviewStatusMutation = useMutation({
+    mutationFn: updateQuizReviewStatus,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['incorrectQuizzes'] });
+    },
+    onError: (error) => {
+      console.error('오답노트 상태 업데이트 실패:', error);
+    },
+  });
+
+  return {
+    incorrectQuizzes,
+    isPending,
+    isError,
+    error,
+    updateQuizReviewStatus: updateQuizReviewStatusMutation.mutate,
+  };
+};

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -68,7 +68,7 @@ export default function MyPage() {
           </Card>
 
           <Card>
-            <h3 className="mb-4 text-lg font-medium">업적</h3>
+            <h3 className="mb-4 text-lg font-bold">달성한 업적</h3>
             {achievedAchievements.length > 0 ? (
               <div className="space-y-4">
                 {achievedAchievements.map((achievement) => (

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,4 @@
 export { default as GamePage } from './game/GamePage';
 export { default as SearchPage } from './search/SearchPage';
-export { default as MyPage } from './MyPage';
+export { default as MyPage } from './profile/MyPage';
 export * from './main';

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -12,6 +12,7 @@ import ProfileSkeleton from '../../components/mypage/skeleton/ProfileSkeleton';
 import AchievementSkeleton from '../../components/mypage/skeleton/AchievementSkeleton';
 import FlexBox from '@/components/layout/FlexBox';
 import { useUserData } from '@/api/mypage/useUserData';
+import AboutPage from '@/components/common/AboutPage';
 
 export interface Achievement {
   achievementId: string;
@@ -36,6 +37,11 @@ export default function MyPage() {
 
   return (
     <Container>
+      <AboutPage
+        title="프로필페이지"
+        description="사용자의 프로필, 업적, 퀴즈 현황을 확인할 수 있는 페이지"
+        keywords="마이페이지, 프로필, 업적, 퀴즈, 사용자 통계"
+      />
       <TopBar />
       {isLoading ? (
         <>

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -32,6 +32,8 @@ export default function MyPage() {
         .slice(0, 3)
     : [];
 
+  console.log(profileData);
+
   return (
     <Container>
       <TopBar />
@@ -62,7 +64,9 @@ export default function MyPage() {
               </div>
               <div>
                 <p className="text-sm text-gray-500">정답률</p>
-                <p className="text-xl font-bold text-center">{profileData?.correctRate}%</p>
+                <p className="text-xl font-bold text-center">
+                  {Math.floor((profileData?.correctRate ?? 0) * 100)}%
+                </p>
               </div>
             </div>
           </Card>

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -33,8 +33,6 @@ export default function MyPage() {
         .slice(0, 3)
     : [];
 
-  console.log(profileData);
-
   return (
     <Container>
       <AboutPage

--- a/src/pages/profile/MyPage.tsx
+++ b/src/pages/profile/MyPage.tsx
@@ -8,8 +8,8 @@ import { useModal } from '@/hooks/useModal';
 import { AchievementModal } from '@/components/mypage/AchievementModal';
 import UserModal from '@/components/mypage/UserModal';
 import WithDrawalModal from '@/components/mypage/WithDrawalModal';
-import ProfileSkeleton from '../components/mypage/skeleton/ProfileSkeleton';
-import AchievementSkeleton from '../components/mypage/skeleton/AchievementSkeleton';
+import ProfileSkeleton from '../../components/mypage/skeleton/ProfileSkeleton';
+import AchievementSkeleton from '../../components/mypage/skeleton/AchievementSkeleton';
 import FlexBox from '@/components/layout/FlexBox';
 import { useUserData } from '@/api/mypage/useUserData';
 

--- a/src/pages/profile/ReviewNote.tsx
+++ b/src/pages/profile/ReviewNote.tsx
@@ -5,6 +5,7 @@ import Container from '@/components/layout/Container';
 import FlexBox from '@/components/layout/FlexBox';
 import { Loader2 } from 'lucide-react';
 import { useReviewNote } from '@/hooks/useReviewNote';
+import AboutPage from '@/components/common/AboutPage';
 
 export default function ReviewNote() {
   const { incorrectQuizzes, isPending, isError, error, updateQuizReviewStatus } = useReviewNote();
@@ -12,6 +13,11 @@ export default function ReviewNote() {
 
   return (
     <Container>
+      <AboutPage
+        title="오답노트"
+        description="사용자가 틀린 퀴즈들의 오답노트를 확인 할 수 있는 페이지"
+        keywords="퀴즈, 오답노트"
+      />
       <TopBar leftIcon="left" leftText="오답노트" onClickLeft={() => navigate('/profile')} />
       {isPending ? (
         <div className="flex justify-center items-center h-[calc(100vh-100px)]">

--- a/src/pages/profile/ReviewNote.tsx
+++ b/src/pages/profile/ReviewNote.tsx
@@ -1,32 +1,14 @@
+import { useNavigate } from 'react-router-dom';
 import TopBar from '@/components/common/TopBar';
 import ReviewNoteCard from '@/components/mypage/ReviewNoteCard';
-import { useNavigate } from 'react-router-dom';
 import Container from '@/components/layout/Container';
 import FlexBox from '@/components/layout/FlexBox';
-import axiosInstance from '@/api/axiosInstance';
-import { useQuery } from '@tanstack/react-query';
-import { QuizWithAnswer } from '@/types/WrongQuizTypes';
 import { Loader2 } from 'lucide-react';
-
-const fetchIncorrectAnswers = async () => {
-  const response = await axiosInstance.get<{ result: { content: QuizWithAnswer[] } }>(
-    '/quiz/user-answers/incorrect',
-  );
-  return response.data.result.content;
-};
+import { useReviewNote } from '@/hooks/useReviewNote';
 
 export default function ReviewNote() {
+  const { incorrectQuizzes, isPending, isError, error, updateQuizReviewStatus } = useReviewNote();
   const navigate = useNavigate();
-
-  const {
-    data: incorrectQuizzes = [],
-    isPending,
-    isError,
-    error,
-  } = useQuery<QuizWithAnswer[], Error>({
-    queryKey: ['incorrectQuizzes'],
-    queryFn: fetchIncorrectAnswers,
-  });
 
   return (
     <Container>
@@ -36,7 +18,7 @@ export default function ReviewNote() {
           <Loader2 className="h-16 w-16 text-blue-500 animate-spin" />
         </div>
       ) : isError ? (
-        <div>오류가 발생했습니다: {error.message}</div>
+        <div>오류가 발생했습니다: {error!.message}</div>
       ) : incorrectQuizzes.length === 0 ? (
         <div className="flex justify-center items-center h-[calc(100vh-100px)] text-gray-500">
           틀린 문제가 없습니다
@@ -45,7 +27,7 @@ export default function ReviewNote() {
         <FlexBox direction="col" className="gap-4">
           {incorrectQuizzes.map((quizData) => (
             <div key={quizData.quiz.id} className="w-full">
-              <ReviewNoteCard quizData={quizData} />
+              <ReviewNoteCard quizData={quizData} onUpdate={updateQuizReviewStatus} />
             </div>
           ))}
         </FlexBox>


### PR DESCRIPTION
## 📌 작업 개요 
MyPage 오답노트 삭제기능 추가 및 UI개선

## 👩‍💻 요구 사항과 구현 내용 
- 오답노트 삭제 api연동
- MyPage 프로필 부분 정답률 UI개선
- AboutPage 설정

![정답률](https://github.com/user-attachments/assets/a263c235-d36e-42c8-a732-4e1b84bedc48)

AboutPage부분 한번 확인해주시면 감사하겠습니다.