### PR TITLE
[FEAT] createBrowserRouter 추가 및 무한 스크롤 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,65 +1,10 @@
-import { useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import MainLayout from './components/layout/MainLayout';
-import AuthLayout from './components/layout/AuthLayout';
-import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
-import { GamePage, MainPage, MyPage, SearchPage } from './pages';
-import {
-  AbPage,
-  OxPage,
-  MultipleChoicePage,
-  EditOxQuizPage,
-  EditAbQuizPage,
-  EditMultipleQuizPage,
-} from './pages/quiz';
-import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play, Result } from './pages/game';
-import ReviewNote from './pages/profile/ReviewNote';
-import QuizManagement from './pages/profile/QuizManagement';
-import NotFound from './components/game/NotFound';
-
-// [Should]: AuthLayout과 MainLayout에서 로그인 여부를 체크하여 로그인 여부에 따라 접근 제한을 하시는게 좋을거같습니다.
+import { RouterProvider } from 'react-router-dom';
+import createRoutes from './routes';
 
 function App() {
-  const [activeTab, setActiveTab] = useState('home');
+  const router = createRoutes();
 
-  return (
-    <Router>
-      <Routes>
-        {/* 인증 관련 경로 AuthLayout*/}
-        <Route element={<AuthLayout />}>
-          <Route path="/" element={<LoginPage />} />
-          <Route path="/oauth/kakao/callback" element={<CallbackPage provider="kakao" />} />
-          <Route path="/oauth/google/callback" element={<CallbackPage provider="google" />} />
-          <Route path="/interest" element={<InterestPage />} />
-        </Route>
-
-        {/* 그 외 BottomNavbar 사용시 MainLayout */}
-        <Route element={<MainLayout activeTab={activeTab} setActiveTab={setActiveTab} />}>
-          <Route path="/main" element={<MainPage />} />
-          <Route path="/game" element={<GamePage />} />
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/profile" element={<MyPage />} />
-          <Route path="/profile/reviewNote" element={<ReviewNote />} />
-          <Route path="/profile/quizManagement" element={<QuizManagement />} />
-          <Route path="/game/create" element={<CreateGame />} />
-          <Route path="/game/random" element={<RandomMatch />} />
-          <Route path="/game/entry" element={<CodeEntry />} />
-          <Route path="/quiz/ab" element={<AbPage />} />
-          <Route path="/quiz/ox" element={<OxPage />} />
-          <Route path="/quiz/multiple" element={<MultipleChoicePage />} />
-          <Route path="/quiz/edit/ox/:id" element={<EditOxQuizPage />} />
-          <Route path="/quiz/edit/ab/:id" element={<EditAbQuizPage />} />
-          <Route path="/quiz/edit/multiple/:id" element={<EditMultipleQuizPage />} />
-          {/* 추가적인 페이지 라우팅을 등록 */}
-        </Route>
-        <Route path="/game/waiting" element={<WaitingRoom />} />
-        <Route path="/game/play" element={<Play />} />
-        <Route path="/game/result" element={<Result />} />
-        {/* 404 페이지 처리 */}
-        <Route path="*" element={<NotFound message="404: 적절하지 않은 접근 경로입니다" />} />
-      </Routes>
-    </Router>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/api/quiz/useFetchMyQuizzes.ts
+++ b/src/api/quiz/useFetchMyQuizzes.ts
@@ -1,15 +1,23 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 
+const PAGE_SIZE = 10;
+
+async function fetchMyQuizzes({ pageParam = 0 }) {
+  const response = await axiosInstance.get(`/quiz/my-quizzes?page=${pageParam}&size=${PAGE_SIZE}`);
+  return {
+    data: response.data.result.content,
+    nextPage: pageParam + 1,
+    isLast: response.data.result.last, // 마지막 페이지인지 여부
+  };
+}
+
 function useFetchMyQuizzes() {
-  return useQuery({
-    queryKey: ['myQuizzes'], // 고정된 키
-    queryFn: async () => {
-      const response = await axiosInstance.get('/quiz/my-quizzes?page=0&size=10'); // 기본 API 호출
-      return response.data;
-    },
-    staleTime: 1000 * 60, // 1분 동안 캐시 데이터 유지 후 다시 가져옴
-    retry: 2, // 실패 시 2회 재시도
+  return useInfiniteQuery({
+    queryKey: ['myQuizzes'],
+    queryFn: fetchMyQuizzes,
+    getNextPageParam: (lastPage) => (!lastPage.isLast ? lastPage.nextPage : undefined),
+    initialPageParam: 0,
   });
 }
 

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+const RequireAuth = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  // 인증되지 않은 사용자는 로그인 페이지로 리다이렉트
+  if (!isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+  return <Outlet />;
+};
+
+export default RequireAuth;

--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -6,7 +6,7 @@ import { IoGameControllerOutline } from 'react-icons/io5';
 const BottomNavBar = ({ activeTab, setActiveTab }: NavBarType) => {
   const navigate = useNavigate();
   const tabs = [
-    { id: 'home', label: '메인', icon: <Icon icon="home" />, path: '/main' },
+    { id: 'main', label: '메인', icon: <Icon icon="home" />, path: '/main' },
     {
       id: 'game',
       label: '게임',

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,19 +1,29 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { BottomNavBar } from '..';
 import { ProtectedLayout } from './ProtectedLayout';
+import { useEffect, useMemo } from 'react';
 
-function MainLayout({
-  activeTab,
-  setActiveTab,
-}: {
-  activeTab: string;
-  setActiveTab: (tab: string) => void;
-}) {
+function MainLayout() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // URL 경로에서 activeTab 추출
+  const activeTab = useMemo(() => {
+    const pathSegments = location.pathname.split('/').filter(Boolean);
+    return pathSegments[0] || 'main'; // 첫 번째 경로를 activeTab으로 사용
+  }, [location.pathname]);
+
+  useEffect(() => {}, [activeTab, navigate]);
+
+  const handleSetActiveTab = (tab: string) => {
+    navigate(`/${tab}`);
+  };
+
   return (
     <ProtectedLayout>
       <div className="min-h-dvh pb-16">
         <Outlet />
-        <BottomNavBar activeTab={activeTab} setActiveTab={setActiveTab} />
+        <BottomNavBar activeTab={activeTab} setActiveTab={handleSetActiveTab} />
       </div>
     </ProtectedLayout>
   );

--- a/src/pages/profile/QuizManagement.tsx
+++ b/src/pages/profile/QuizManagement.tsx
@@ -12,6 +12,7 @@ import Icon from '@eolluga/eolluga-ui/icon/Icon';
 import BadgeIcon from '@eolluga/eolluga-ui/Display/BadgeIcon';
 import Dialog from '@/components/common/Dialog';
 import { convertQuizTypeForURL, convertQuizTypeForDisplay } from '@/utils/quizTypeConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 export default function MyQuizManagement() {
   const navigate = useNavigate();
@@ -70,6 +71,11 @@ export default function MyQuizManagement() {
 
   return (
     <Container>
+      <AboutPage
+        title="내 퀴즈 관리"
+        description="내가 작성한 퀴즈를 확인하고 수정할 수 있는 페이지"
+        keywords="quiz"
+      />
       <TopBar leftIcon="left" leftText="내 퀴즈 관리" onClickLeft={() => navigate('/profile')} />
       <FlexBox>
         <div className="w-full space-y-3">

--- a/src/pages/quiz/AbPage.tsx
+++ b/src/pages/quiz/AbPage.tsx
@@ -167,11 +167,36 @@ export default function ABTestPage() {
         { optionNumber: 2, content: formData.optionB, imageId: formData.imageBId },
       ],
     };
-
     createQuizMutate(payload, {
       onSuccess: () => {
         setToastMessage({ message: '퀴즈가 생성되었습니다!', icon: 'check' });
         setToastOpen(true);
+        // 상태 초기화
+        setFormData({
+          category: '',
+          question: '',
+          optionA: '',
+          optionB: '',
+          imageA: null,
+          imageB: null,
+          imageAId: null,
+          imageBId: null,
+          tags: [],
+        });
+
+        setFieldErrors({
+          category: false,
+          question: false,
+          optionA: false,
+          optionB: false,
+        });
+
+        // 이미지 입력 필드 초기화
+        const imageAInput = document.getElementById('image-a') as HTMLInputElement;
+        const imageBInput = document.getElementById('image-b') as HTMLInputElement;
+
+        if (imageAInput) imageAInput.value = '';
+        if (imageBInput) imageBInput.value = '';
       },
       onError: () => {
         setToastMessage({ message: '퀴즈 생성에 실패했습니다.', icon: 'warning' });
@@ -261,7 +286,7 @@ export default function ABTestPage() {
               <TextField
                 mode="outlined"
                 value={formData.optionA}
-                onChange={(e) => handleInputChange('optionA', e.target.value, 20)}
+                onChange={(e) => handleInputChange('optionA', e.target.value, 30)}
                 placeholder="A 선택지를 입력하세요."
                 size="M"
                 state={fieldErrors.optionA ? 'error' : 'enable'}

--- a/src/pages/quiz/AbPage.tsx
+++ b/src/pages/quiz/AbPage.tsx
@@ -16,6 +16,7 @@ import TagInput from '@/components/common/TagInput';
 import useUploadImage from '@/api/quiz/useUploadImage';
 import useCreateQuiz from '@/api/quiz/useCreateQuiz';
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 // 카테고리 목록
 const categories = [
@@ -181,6 +182,11 @@ export default function ABTestPage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="AB 테스트"
+        description="내가 원하는 주제로 AB 테스트를 만들어보세요."
+        keywords="quiz, AB, 퀴즈, AB 테스트"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/pages/quiz/EditAbQuizPage.tsx
+++ b/src/pages/quiz/EditAbQuizPage.tsx
@@ -267,7 +267,7 @@ export default function EditABTestPage() {
               <Label content="A 선택지" />
               <TextField
                 value={updatedQuizData.optionA}
-                onChange={(e) => handleInputChange('optionA', e.target.value, 20)} // 선택지는 20자 제한
+                onChange={(e) => handleInputChange('optionA', e.target.value, 30)} // 선택지는 20자 제한
                 placeholder="A 선택지를 입력하세요."
                 size="M"
                 state={fieldErrors.optionA ? 'error' : 'enable'}

--- a/src/pages/quiz/EditAbQuizPage.tsx
+++ b/src/pages/quiz/EditAbQuizPage.tsx
@@ -18,6 +18,7 @@ import useUpdateQuiz from '@/api/quiz/useUpdateQuiz';
 import { useFetchQuizData, fetchImageUrl } from '@/api/quiz/useFetchQuizData';
 import { uploadImage } from '@/api/quiz/useUploadImage';
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 // 카테고리 목록
 const categories = [
@@ -191,6 +192,11 @@ export default function EditABTestPage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="AB 테스트"
+        description="내가 만든 AB 테스트를 수정하기 위한 페이지입니다."
+        keywords="quiz, AB, 퀴즈, AB 테스트"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/pages/quiz/EditMultipleQuizPage.tsx
+++ b/src/pages/quiz/EditMultipleQuizPage.tsx
@@ -87,7 +87,7 @@ export default function EditMultipleChoicePage() {
   // 선택지 변경 핸들러
   const handleOptionChange = (optionNumber: number, value: string) => {
     const updatedOptions = updatedQuizData.options.map((option) =>
-      option.optionNumber === optionNumber ? { ...option, content: value.slice(0, 20) } : option,
+      option.optionNumber === optionNumber ? { ...option, content: value.slice(0, 30) } : option,
     );
     setUpdatedQuizData((prev) => ({ ...prev, options: updatedOptions }));
 

--- a/src/pages/quiz/EditMultipleQuizPage.tsx
+++ b/src/pages/quiz/EditMultipleQuizPage.tsx
@@ -17,6 +17,7 @@ import TagInput from '@/components/common/TagInput';
 import useUpdateQuiz from '@/api/quiz/useUpdateQuiz';
 import useFetchQuizData from '@/api/quiz/useFetchQuizData';
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 const categories = [
   '알고리즘',
@@ -173,6 +174,11 @@ export default function EditMultipleChoicePage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="객관식 퀴즈"
+        description="내가 만든 객관식 퀴즈를 수정하기 위한 페이지입니다."
+        keywords="quiz, Multiple, 퀴즈, 객관식 퀴즈"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/pages/quiz/EditOxQuizPage.tsx
+++ b/src/pages/quiz/EditOxQuizPage.tsx
@@ -16,6 +16,7 @@ import TagInput from '@/components/common/TagInput';
 import useUpdateQuiz from '@/api/quiz/useUpdateQuiz';
 import useFetchQuizData from '@/api/quiz/useFetchQuizData'; // React Query 훅
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 const categories = [
   '알고리즘',
@@ -142,6 +143,11 @@ export default function EditOxQuizPage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="OX 퀴즈"
+        description="내가 만든 OX 퀴즈를 수정하기 위한 페이지입니다."
+        keywords="quiz, OX, 퀴즈, OX 퀴즈"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/pages/quiz/MultipleChoicePage.tsx
+++ b/src/pages/quiz/MultipleChoicePage.tsx
@@ -15,6 +15,7 @@ import ToastMessage from '@/components/common/ToastMessage';
 import TagInput from '@/components/common/TagInput';
 import useCreateQuiz from '@/api/quiz/useCreateQuiz';
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 // 카테고리 목록
 const categories = [
@@ -190,6 +191,11 @@ export default function MultipleChoicePage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="객관식 퀴즈"
+        description="내가 원하는 주제로 객관식 퀴즈를 만들어보세요."
+        keywords="quiz, Multiple, 퀴즈, 객관식 퀴즈"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/pages/quiz/MultipleChoicePage.tsx
+++ b/src/pages/quiz/MultipleChoicePage.tsx
@@ -101,7 +101,7 @@ export default function MultipleChoicePage() {
   // 선택지 변경 핸들러
   const handleOptionChange = (index: number, value: string) => {
     const updatedOptions = [...formData.options];
-    updatedOptions[index] = value.slice(0, 20); // 선택지 최대 글자 수 제한
+    updatedOptions[index] = value.slice(0, 30); // 선택지 최대 글자 수 제한
     setFormData((prev) => ({
       ...prev,
       options: updatedOptions,
@@ -181,6 +181,23 @@ export default function MultipleChoicePage() {
       onSuccess: () => {
         setToastMessage({ message: '퀴즈가 생성되었습니다!', icon: 'check' });
         setToastOpen(true);
+        // 상태 초기화
+        setFormData({
+          category: '',
+          question: '',
+          options: ['', '', '', ''],
+          selectedAnswer: null,
+          explanation: '',
+          tags: [],
+        });
+
+        setFieldErrors({
+          category: false,
+          question: false,
+          options: [false, false, false, false],
+          explanation: false,
+          selectedAnswer: false,
+        });
       },
       onError: () => {
         setToastMessage({ message: '퀴즈 생성에 실패했습니다.', icon: 'warning' });

--- a/src/pages/quiz/OxPage.tsx
+++ b/src/pages/quiz/OxPage.tsx
@@ -134,11 +134,26 @@ export default function OXQuizPage() {
       answerNumber,
       explanation: formData.explanation,
     };
-
     createQuizMutate(payload, {
       onSuccess: () => {
         setToastMessage({ message: '퀴즈가 생성되었습니다!', icon: 'check' });
         setToastOpen(true);
+        // 상태 초기화
+        setFormData({
+          category: '',
+          question: '',
+          selectedAnswer: null,
+          explanation: '',
+          tags: [],
+        });
+
+        // 에러 상태도 초기화
+        setFieldErrors({
+          category: false,
+          question: false,
+          explanation: false,
+          selectedAnswer: false,
+        });
       },
       onError: () => {
         setToastMessage({ message: '퀴즈 생성에 실패했습니다.', icon: 'warning' });

--- a/src/pages/quiz/OxPage.tsx
+++ b/src/pages/quiz/OxPage.tsx
@@ -14,6 +14,7 @@ import ToastMessage from '@/components/common/ToastMessage';
 import TagInput from '@/components/common/TagInput';
 import useCreateQuiz from '@/api/quiz/useCreateQuiz';
 import { toEnglishCategory } from '@/utils/categoryConverter';
+import AboutPage from '@/components/common/AboutPage';
 
 // 카테고리 목록
 const categories = [
@@ -148,6 +149,11 @@ export default function OXQuizPage() {
 
   return (
     <FlexBox direction="col">
+      <AboutPage
+        title="OX 퀴즈"
+        description="내가 원하는 주제로 OX 퀴즈를 만들어보세요."
+        keywords="quiz, OX, 퀴즈, OX 퀴즈"
+      />
       <Container>
         <TopBar
           leftIcon="left"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,76 @@
+import { createBrowserRouter } from 'react-router-dom';
+import MainLayout from './components/layout/MainLayout';
+import AuthLayout from './components/layout/AuthLayout';
+import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
+import { GamePage, MainPage, MyPage, SearchPage } from './pages';
+import {
+  AbPage,
+  OxPage,
+  MultipleChoicePage,
+  EditOxQuizPage,
+  EditAbQuizPage,
+  EditMultipleQuizPage,
+} from './pages/quiz';
+import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play, Result } from './pages/game';
+import ReviewNote from './pages/profile/ReviewNote';
+import QuizManagement from './pages/profile/QuizManagement';
+import NotFound from './components/game/NotFound';
+import { useState } from 'react';
+
+const createRoutes = () => {
+  const [activeTab, setActiveTab] = useState('home');
+  // [Should]: AuthLayout과 MainLayout에서 로그인 여부를 체크하여 로그인 여부에 따라 접근 제한을 하시는게 좋을거같습니다.
+  return createBrowserRouter([
+    {
+      path: '/',
+      element: <AuthLayout />,
+      children: [
+        { path: '/', element: <LoginPage /> },
+        { path: '/oauth/kakao/callback', element: <CallbackPage provider="kakao" /> },
+        { path: '/oauth/google/callback', element: <CallbackPage provider="google" /> },
+        { path: '/interest', element: <InterestPage /> },
+      ],
+    },
+    {
+      element: <MainLayout activeTab={activeTab} setActiveTab={setActiveTab} />,
+      children: [
+        { path: '/main', element: <MainPage /> },
+        { path: '/game', element: <GamePage /> },
+        { path: '/search', element: <SearchPage /> },
+        {
+          path: '/profile',
+          children: [
+            { path: '', element: <MyPage /> },
+            { path: 'reviewNote', element: <ReviewNote /> },
+            { path: 'quizManagement', element: <QuizManagement /> },
+          ],
+        },
+        {
+          path: '/quiz',
+          children: [
+            { path: 'ox', element: <OxPage /> },
+            { path: 'ab', element: <AbPage /> },
+            { path: 'multiple', element: <MultipleChoicePage /> },
+            { path: 'edit/ox/:id', element: <EditOxQuizPage /> },
+            { path: 'edit/ab/:id', element: <EditAbQuizPage /> },
+            { path: 'edit/multiple/:id', element: <EditMultipleQuizPage /> },
+          ],
+        },
+        {
+          path: '/game',
+          children: [
+            { path: 'create', element: <CreateGame /> },
+            { path: 'random', element: <RandomMatch /> },
+            { path: 'entry', element: <CodeEntry /> },
+          ],
+        },
+      ],
+    },
+    { path: '/game/waiting', element: <WaitingRoom /> },
+    { path: '/game/play', element: <Play /> },
+    { path: '/game/result', element: <Result /> },
+    { path: '*', element: <NotFound message="404: 적절하지 않은 접근 경로입니다" /> },
+  ]);
+};
+
+export default createRoutes;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,10 +15,8 @@ import { CreateGame, WaitingRoom, RandomMatch, CodeEntry, Play, Result } from '.
 import ReviewNote from './pages/profile/ReviewNote';
 import QuizManagement from './pages/profile/QuizManagement';
 import NotFound from './components/game/NotFound';
-import { useState } from 'react';
 
 const createRoutes = () => {
-  const [activeTab, setActiveTab] = useState('home');
   // [Should]: AuthLayout과 MainLayout에서 로그인 여부를 체크하여 로그인 여부에 따라 접근 제한을 하시는게 좋을거같습니다.
   return createBrowserRouter([
     {
@@ -32,7 +30,7 @@ const createRoutes = () => {
       ],
     },
     {
-      element: <MainLayout activeTab={activeTab} setActiveTab={setActiveTab} />,
+      element: <MainLayout />,
       children: [
         { path: '/main', element: <MainPage /> },
         { path: '/game', element: <GamePage /> },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import MainLayout from './components/layout/MainLayout';
 import AuthLayout from './components/layout/AuthLayout';
+import RequireAuth from './components/auth/RequireAuth';
 import { LoginPage, InterestPage, CallbackPage } from './pages/Login';
 import { GamePage, MainPage, MyPage, SearchPage } from './pages';
 import {
@@ -30,36 +31,41 @@ const createRoutes = () => {
       ],
     },
     {
-      element: <MainLayout />,
+      element: <RequireAuth />, // 인증 가드 추가
       children: [
-        { path: '/main', element: <MainPage /> },
-        { path: '/game', element: <GamePage /> },
-        { path: '/search', element: <SearchPage /> },
         {
-          path: '/profile',
+          element: <MainLayout />,
           children: [
-            { path: '', element: <MyPage /> },
-            { path: 'reviewNote', element: <ReviewNote /> },
-            { path: 'quizManagement', element: <QuizManagement /> },
-          ],
-        },
-        {
-          path: '/quiz',
-          children: [
-            { path: 'ox', element: <OxPage /> },
-            { path: 'ab', element: <AbPage /> },
-            { path: 'multiple', element: <MultipleChoicePage /> },
-            { path: 'edit/ox/:id', element: <EditOxQuizPage /> },
-            { path: 'edit/ab/:id', element: <EditAbQuizPage /> },
-            { path: 'edit/multiple/:id', element: <EditMultipleQuizPage /> },
-          ],
-        },
-        {
-          path: '/game',
-          children: [
-            { path: 'create', element: <CreateGame /> },
-            { path: 'random', element: <RandomMatch /> },
-            { path: 'entry', element: <CodeEntry /> },
+            { path: '/main', element: <MainPage /> },
+            { path: '/game', element: <GamePage /> },
+            { path: '/search', element: <SearchPage /> },
+            {
+              path: '/profile',
+              children: [
+                { path: '', element: <MyPage /> },
+                { path: 'reviewNote', element: <ReviewNote /> },
+                { path: 'quizManagement', element: <QuizManagement /> },
+              ],
+            },
+            {
+              path: '/quiz',
+              children: [
+                { path: 'ox', element: <OxPage /> },
+                { path: 'ab', element: <AbPage /> },
+                { path: 'multiple', element: <MultipleChoicePage /> },
+                { path: 'edit/ox/:id', element: <EditOxQuizPage /> },
+                { path: 'edit/ab/:id', element: <EditAbQuizPage /> },
+                { path: 'edit/multiple/:id', element: <EditMultipleQuizPage /> },
+              ],
+            },
+            {
+              path: '/game',
+              children: [
+                { path: 'create', element: <CreateGame /> },
+                { path: 'random', element: <RandomMatch /> },
+                { path: 'entry', element: <CodeEntry /> },
+              ],
+            },
           ],
         },
       ],


### PR DESCRIPTION
### 피드백
- meta 데이터 동적 설정 추가
- createBrowserRouter 를 이용한 라우터 정의
- 기존 새로고침시 NavBar 메인으로 이동하던 문제 해결 ( id: home -> id: main) 

- queryKey는 하다가 뭔가 좀 잘 안돼서 보류했습니다.
---
- 무한 스크롤 테스트 필요 (코드 살짝 고쳤는데 현재 접속 에러나서 테스트 못함)